### PR TITLE
feat: add Stage 9 (Skill Audit) to pipeline, fix stale skills

### DIFF
--- a/.gemini/skills/red-green-yellow/SKILL.md
+++ b/.gemini/skills/red-green-yellow/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: tdd-red-green-refactor
+description: >
+  Enforces a disciplined Red-Green-Refactor (TDD) workflow in TypeScript/Node.js. 
+  Use this whenever creating new features, fixing bugs, or migrating logic to ensure 
+  high-quality, verifiable implementations.
+---
+
+# Red-Green-Refactor (TDD) Skill: TypeScript Edition
+
+This skill implements a structural framework for AI-assisted programming to ensure every line of code is verifiable, typed, and purposeful.
+
+## The Three-Phase Cycle
+
+### Phase 1: Red (Establish Failure)
+You must prove the feature does not exist and that your test is valid.
+1. **Write One Test**: Create a single test case (e.g., in Vitest or Jest) for the next small piece of behavior.
+2. **Execute & Fail**: Run the test. It must fail. 
+3. **Verify**: Ensure the failure is related to the missing logic (e.g., `ReferenceError: add is not defined`) and not a configuration error.
+
+### Phase 2: Green (Minimal Pass)
+Make the test pass as quickly and simply as possible.
+1. **Minimal Implementation**: Write the simplest code that satisfies the test. Do not build for the future; focus strictly on the current "Red" test.
+2. **Run Tests**: Execute the suite. All tests must be Green.
+3. **Evidence**: The transition from Red to Green is the "Proof of Work" for the developer.
+
+### Phase 3: Refactor (Clean Up)
+Improve the code structure while maintaining the "Green" state.
+1. **Clean Up**: Improve naming, remove duplication, and optimize the code written in Phase 2.
+2. **Safety Net**: Rerun the tests after every change. If they turn Red, revert the change immediately.
+
+---
+
+## Core Operational Rules
+
+### 1. No "Horizontal Splurging"
+You are strictly forbidden from writing a large "splurge" of multiple tests at once. You must follow a strictly incremental loop:
+- **Write 1 Test -> See it Fail -> Write 1 Fix -> See it Pass**.
+- Repeat this loop for every sub-feature.
+
+### 2. Impose Backpressure
+Use automated assertions and strong typing (TypeScript) as backpressure to prevent the AI from "guessing" the solution or "playing in the mud" with low-quality code.
+
+### 3. Verification of Integrity
+Never modify an existing test to make a failing implementation pass. If a test must change, it must be because the requirement changed, not because the code is difficult to write.
+
+---
+
+## Example Workflow (TypeScript + Vitest)
+
+**Step 1: Red**
+```typescript
+// math.test.ts
+import { describe, it, expect } from 'vitest';
+import { add } from './math';
+
+describe('add', () => {
+  it('should sum two numbers', () => {
+    expect(add(2, 2)).toBe(4); // Fails: ReferenceError: add is not defined
+  });
+});
+```
+
+**Step 2: Green**
+```typescript
+// math.ts
+export const add = (a: any, b: any) => {
+  return 4; // Passes: Minimal code to satisfy the test
+};
+```
+
+**Step 3: Refactor**
+```typescript
+// math.ts
+/**
+ * Sums two numbers with explicit type safety.
+ */
+export const add = (a: number, b: number): number => {
+  return a + b; // Passes: Proper implementation with safety net
+};
+```

--- a/.gemini/skills/stitch-sdk-development/SKILL.md
+++ b/.gemini/skills/stitch-sdk-development/SKILL.md
@@ -1,199 +1,217 @@
 ---
 name: stitch-sdk-development
-description: Contribute to the Stitch SDK codebase. Use when adding new operations, fixing bugs, or understanding the SDK architecture. Follows the Spec & Handler zero-contention pattern.
+description: Develop the Stitch SDK. Covers the generation pipeline, dual modality (agent vs SDK), error handling, and Traffic Light (Red-Green-Yellow) implementation workflow. Use when adding features, fixing bugs, or understanding the architecture.
 ---
 
-# Developing the Stitch SDK
+# Stitch SDK Development
 
-This skill covers contributing to the Stitch SDK codebase.
+This skill encodes the expertise needed to develop `@google/stitch-sdk` — the core systems, patterns, and philosophies. It does not enumerate every method (the codebase is the source of truth for that). It teaches you how to think about the system.
 
-## Architecture Overview
+---
 
-The SDK uses a **Spec & Handler** pattern for zero-contention development:
+## The Generation Pipeline
+
+The domain layer is **fully generated**. No handwritten domain classes. The pipeline has 3 stages:
 
 ```
-core/src/
-├── methods/                    # All operations by domain
-│   ├── stitch/                 # Stitch-level (connect, projects)
-│   │   └── {operation}/
-│   │       ├── spec.ts         # Input/output schemas
-│   │       └── handler.ts      # Implementation
-│   ├── project/                # Project-level (generate, screens)
-│   └── screen/                 # Screen-level (getHtml, getImage)
-├── proxy/                      # MCP Proxy server
-└── spec/                       # Shared specifications
+Stage 1: Capture            Stage 2: Domain Design       Stage 3: Generate
+┌──────────────────┐       ┌──────────────────┐        ┌──────────────────┐
+│ capture-tools.ts │──────▶│  domain-map.json │───────▶│ generate-sdk.ts  │
+│                  │       │  (the IR)        │        │                  │
+│ Connects to MCP  │       │ Classes, bindings│        │ Deterministic    │
+│ server, calls    │       │ arg routing,     │        │ codegen into     │
+│ tools/list       │       │ cache, extraction│        │ core/generated/  │
+└──────────────────┘       └──────────────────┘        └──────────────────┘
+        │                          │                           │
+        ▼                          ▼                           ▼
+ tools-manifest.json        domain-map.json          core/generated/src/*.ts
+ (raw MCP tool schemas)     (tool→class mapping)     (Stitch, Project, Screen)
 ```
 
-## Adding a New Operation
+**Stage 1** (`bun scripts/capture-tools.ts`): Connects to the live Stitch MCP server, calls `tools/list`, writes `tools-manifest.json`. Source of truth for what tools exist.
 
-### 1. Create the Folder
+**Stage 2** (agent/human): Reads the manifest and produces `domain-map.json` — the intermediate representation. This is where judgment lives: which tool maps to which class, what args come from `self` vs `param` vs `computed`, how to extract the return value, and what data to cache.
 
-```bash
-mkdir -p core/src/methods/{domain}/{operationName}
-```
+**Stage 3** (`bun scripts/generate-sdk.ts`): Deterministic codegen. Reads manifest + domain-map, emits TypeScript classes in `core/generated/src/`. No LLM involved — pure template expansion.
 
-### 2. Create spec.ts
+**Integrity**: `stitch-sdk.lock` records SHA-256 hashes of all inputs and outputs. `bun scripts/validate-generated.ts` verifies consistency. Run in CI to prevent publishing stale code.
 
-```typescript
-import { z } from 'zod';
-import type { Result } from '../../../result.js';
+### Supporting a New Tool
 
-// Input schema
-export const MyOperationInputSchema = z.object({
-  projectId: z.string(),
-  // ... other fields
-});
+When the Stitch MCP server adds a new tool:
 
-// Types
-export type MyOperationInput = z.infer<typeof MyOperationInputSchema>;
-export type MyOperationResult = Result<YourReturnType>;
+1. Run Stage 1 to capture the updated manifest
+2. Run Stage 2: add a binding in `domain-map.json` for the new tool
+3. Run Stage 3 to regenerate the SDK classes
+4. Run `validate-generated.ts` to confirm consistency
+5. Update tests as needed
 
-// Interface
-export interface MyOperationSpec {
-  execute(input: MyOperationInput): Promise<MyOperationResult>;
-}
-```
+### The Domain Map IR
 
-### 3. Create handler.ts
+`domain-map.json` expresses two things:
 
-```typescript
-import type { StitchMCPClient } from '../../../client.js';
-import type { MyOperationSpec, MyOperationInput, MyOperationResult } from './spec.js';
-import { ok, failFromError } from '../../../result.js';
-
-export class MyOperationHandler implements MyOperationSpec {
-  constructor(private client: StitchMCPClient) {}
-
-  async execute(input: MyOperationInput): Promise<MyOperationResult> {
-    try {
-      const response = await this.client.callTool('tool_name', {
-        // map input to tool params
-      });
-      return ok(response);
-    } catch (error) {
-      return failFromError(error);
-    }
+**Classes**: What domain objects exist and how they're constructed.
+```json
+{
+  "Screen": {
+    "constructorParams": ["projectId", "screenId"],
+    "fieldMapping": {
+      "projectId": { "from": "projectId" },
+      "screenId": { "from": "id", "fallback": { "field": "name", "splitOn": "/screens/" } }
+    },
+    "parentField": "projectId",
+    "idField": "screenId"
   }
 }
 ```
 
-### 4. Update Barrel Exports
-
-```bash
-bun scripts/generate-barrels.ts
-```
-
-Or manually add to `core/src/methods/index.ts`.
-
-### 5. Add to Wrapper Class
-
-In the appropriate class (`sdk.ts`, `project.ts`, or `screen.ts`):
-
-```typescript
-import { MyOperationHandler } from './methods/{domain}/{operation}/handler.js';
-
-export class Project {
-  private _myOperation: MyOperationHandler;
-
-  constructor(private client: StitchMCPClient) {
-    this._myOperation = new MyOperationHandler(client);
-  }
-
-  async myOperation(param: string): Promise<Result<ReturnType>> {
-    return this._myOperation.execute({ projectId: this.id, param });
+**Bindings**: How MCP tools map to class methods.
+```json
+{
+  "tool": "generate_screen_from_text",
+  "class": "Project",
+  "method": "generate",
+  "args": {
+    "projectId": { "from": "self" },
+    "prompt": { "from": "param" },
+    "name": { "from": "computed", "template": "projects/{projectId}/screens/{screenId}" }
+  },
+  "returns": {
+    "class": "Screen",
+    "projection": [
+      { "prop": "outputComponents", "index": 0 },
+      { "prop": "design" },
+      { "prop": "screens", "index": 0 }
+    ]
   }
 }
 ```
 
-### 6. Create Test
+**Arg routing**: `self` = injected from `this`, `param` = passed by the caller, `computed` = built from a template at call time, `selfArray` = `[this.field]` wrapped as array.
+
+**Response projections**: Structured `ProjectionStep[]` arrays validated against `outputSchema`. Use `index` for single items, `each` for arrays. Empty `[]` = direct return.
+
+**Cache**: Methods can specify a `cache` with a structured `projection` to check `this.data` before calling the API:
+```json
+{
+  "cache": { "projection": [{ "prop": "htmlCode" }, { "prop": "downloadUrl" }], "description": "Use cached download URL from generation response" }
+}
+```
+
+---
+
+## Dual Modality
+
+The SDK serves two distinct consumers with different needs:
+
+### Agent Modality — `StitchToolClient`
+
+For AI agents and orchestration scripts. Raw tool pipe. The agent receives tool schemas, constructs JSON, sends it, gets JSON back. No domain knowledge required.
 
 ```typescript
-// core/test/unit/methods/{domain}/{operation}.test.ts
-import { describe, it, expect, vi } from 'vitest';
-import { MyOperationHandler } from '../../../../src/methods/{domain}/{operation}/handler.js';
-
-describe('MyOperationHandler', () => {
-  it('returns success with expected data', async () => {
-    const mockClient = {
-      callTool: vi.fn().mockResolvedValue({ /* mock response */ }),
-    };
-
-    const handler = new MyOperationHandler(mockClient as any);
-    const result = await handler.execute({ projectId: 'test' });
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toBeDefined();
-    }
-  });
-
-  it('returns failure on error', async () => {
-    const mockClient = {
-      callTool: vi.fn().mockRejectedValue(new Error('API error')),
-    };
-
-    const handler = new MyOperationHandler(mockClient as any);
-    const result = await handler.execute({ projectId: 'test' });
-
-    expect(result.success).toBe(false);
-  });
+const client = new StitchToolClient();
+const tools = await client.listTools();
+const result = await client.callTool("generate_screen_from_text", {
+  projectId: "123", prompt: "A login page"
 });
 ```
 
-## Running Tests
+### SDK Modality — Generated Domain Classes
 
-```bash
-# All tests
-npm test
-
-# Specific test file
-npx vitest run test/unit/methods/stitch/connect.test.ts
-```
-
-## Building
-
-```bash
-npm run build
-```
-
-## Key Patterns
-
-### Result Type
-
-Always return `Result<T>`, never throw:
+For humans writing precise, programmatic scripts. Generated domain facade over `callTool`. Typed parameters, domain objects returned, `StitchError` thrown on failure.
 
 ```typescript
-import { ok, fail, failFromError } from '../../../result.js';
-
-// Success
-return ok(data);
-
-// Known error
-return fail({ code: 'NOT_FOUND', message: 'Project not found', recoverable: false });
-
-// Unknown error
-return failFromError(error);
+const project = await stitch.createProject("My App");
+const screen = await project.generate("A login page");
+const html = await screen.getHtml();
 ```
 
-### Thin Wrappers
+Both modalities share `StitchToolClient` underneath. The domain classes are a typed layer over `callTool`.
 
-Public classes delegate to handlers:
+### Error Handling — Throws at the Boundary
+
+All generated methods use `throw StitchError` for error handling. No `Result<T>` pattern.
 
 ```typescript
-class Screen {
-  private _getHtml: GetScreenHtmlHandler;
-
-  async getHtml(): Promise<Result<string>> {
-    return this._getHtml.execute({ projectId: this.projectId, screenId: this.id });
-  }
+// Generated method pattern (inside each method):
+try {
+  const raw = await this.client.callTool<any>("tool_name", args);
+  return /* extracted result */;
+} catch (error) {
+  throw StitchError.fromUnknown(error);
 }
 ```
 
-### Import Paths
+`StitchError.fromUnknown()` ensures all errors are normalized to `StitchError` with a code, message, and recoverability hint.
+
+### Infrastructure (Handwritten)
+
+These components remain handwritten as they provide foundational plumbing:
+
+- `StitchToolClient` — MCP transport, auth, tool invocation
+- `StitchError` — typed error class with codes, messages, recovery hints
+- `StitchProxy` — MCP proxy server for re-exposing Stitch to other agents
+- `singleton.ts` — lazy proxy for `stitch` export with env var config
+
+---
+
+## Traffic Light Implementation (Red → Green → Yellow)
+
+When implementing a new feature or fixing a bug, follow the Traffic Light pattern:
+
+### 🔴 Red — Write Breaking Tests
+
+Write the test first. It must fail. This defines the contract before any implementation exists.
+
+```bash
+# Unit tests for generated classes
+npx vitest run test/unit/sdk.test.ts
+# → FAIL (new method doesn't exist yet)
+
+# E2E test for the public API
+bun scripts/e2e-test.ts
+# → FAIL (method doesn't exist yet)
+```
+
+### 🟢 Green — Implement
+
+1. Add a binding to `domain-map.json` (Stage 2)
+2. Run `bun scripts/generate-sdk.ts` (Stage 3)
+3. Update tests to verify correct behavior
+
+```bash
+npx vitest run  # All tests pass
+bun scripts/e2e-test.ts  # E2E passes
+```
+
+### 🟡 Yellow — Refactor / Refine / Revisit
+
+With passing tests as your safety net:
+
+- Refactor for clarity (extract helpers, simplify args)
+- Add edge case tests
+- Run `npx tsc` to verify type safety
+- Run `bun scripts/validate-generated.ts` to verify pipeline integrity
+
+---
+
+## Orienting in the Codebase
+
+Discover the current state by reading the codebase directly. The key entry points:
+
+- **Public surface**: Start at `core/src/index.ts` — every public export is listed here
+- **Generated classes**: `core/generated/src/` — Stitch, Project, Screen
+- **Pipeline artifacts**: `core/generated/domain-map.json`, `core/generated/tools-manifest.json`
+- **Infrastructure**: `core/src/client.ts`, `core/src/spec/errors.ts`, `core/src/singleton.ts`
+- **Test structure**: `core/test/unit/` for unit tests, `core/test/integration/` for live tests
+- **Available commands**: Read the `scripts` field in `package.json`
+
+Do not rely on cached descriptions of files or directory trees. Read the source.
+
+## Import Convention
 
 Use `.js` extensions for ESM compatibility:
-
 ```typescript
-import { ok } from '../../../result.js';  // ✓
-import { ok } from '../../../result';     // ✗
+import { StitchError } from '../../src/spec/errors.js';  // ✓
+import { StitchError } from '../../src/spec/errors';     // ✗
 ```

--- a/.gemini/skills/stitch-sdk-domain-design/SKILL.md
+++ b/.gemini/skills/stitch-sdk-domain-design/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: stitch-sdk-domain-design
+description: Design the domain model for the Stitch SDK. Use when mapping MCP tools to domain classes and bindings in domain-map.json. This is Stage 2 of the generation pipeline.
+---
+
+# Stitch SDK Domain Design
+
+This skill teaches you how to perform **Stage 2** of the generation pipeline: reading tool schemas and producing `domain-map.json` — the intermediate representation that drives codegen.
+
+---
+
+## Your Inputs
+
+1. **`tools-manifest.json`** — raw MCP tool schemas captured from the server (includes `outputSchema`)
+2. **`ir-schema.ts`** — Zod schema defining valid domain-map structure (the canonical contract)
+3. **Existing `domain-map.json`** — the current IR (if extending, not starting fresh)
+4. **The `stitch-sdk-development` skill** — for understanding the pipeline context
+
+## Your Output
+
+A valid `domain-map.json` with two sections: `classes` and `bindings`, validated by `ir-schema.ts`.
+
+> [!IMPORTANT]
+> Your output is validated **twice** by the codegen: structurally (Zod IR schema) and semantically (projection steps verified against `outputSchema` from the tools-manifest).
+
+---
+
+## Designing Classes
+
+Each class represents a domain entity. Ask: "What noun does the user interact with?"
+
+```json
+{
+  "Stitch": {
+    "description": "Main entry point. Manages projects.",
+    "constructorParams": [],
+    "isRoot": true,
+    "factories": [
+      { "method": "project", "returns": "Project", "description": "Create a Project handle from an ID." }
+    ]
+  }
+}
+```
+
+### Key decisions:
+
+| Field | Purpose | Example |
+|---|---|---|
+| `constructorParams` | Fields stored on the instance | `["projectId", "screenId"]` |
+| `fieldMapping` | Per-field data source mapping with optional `stripPrefix` | See below |
+| `parentField` | Which param is injected from a parent class | `"projectId"` |
+| `idField` | Which param the `.id` getter aliases | `"screenId"` |
+| `factories` | Local factory methods (no API call) | `[{ "method": "project", "returns": "Project" }]` |
+
+### Field Mapping
+
+Use `fieldMapping` when a param needs a different source field, prefix stripping, or a fallback:
+
+```json
+{
+  "constructorParams": ["projectId", "screenId"],
+  "fieldMapping": {
+    "projectId": { "from": "name", "stripPrefix": "projects/" },
+    "screenId": { "from": "id", "fallback": { "field": "name", "splitOn": "/screens/" } }
+  }
+}
+```
+
+- **`stripPrefix`**: Removes a resource name prefix from the value
+- **`fallback`**: If the primary field is missing, splits an alternate field on a delimiter
+
+---
+
+## Designing Bindings
+
+Each binding maps one MCP tool to one class method. Ask: "Who owns this action?"
+
+### Arg routing
+
+| Type | Meaning | Code generated |
+|---|---|---|
+| `self` | From `this.field` | `projectId: this.projectId` |
+| `param` | From method parameter | `prompt: prompt` |
+| `computed` | Template interpolation | `name: \`projects/${this.projectId}/screens/${screenId}\`` |
+| `selfArray` | Wrap self field as array | `selectedScreenIds: [this.screenId]` |
+
+Optional params use `"optional": true`. Renamed params use `"rename": "newName"`.
+
+### Response Projections
+
+The `returns.projection` array tells codegen how to navigate the API response. Each step is a `ProjectionStep`:
+
+```typescript
+{ prop: string; index?: number; each?: boolean; fallback?: string }
+```
+
+| Projection | Generated code | Use when |
+|---|---|---|
+| `[]` (empty) | `raw` | Direct return (whole response) |
+| `[{ "prop": "projects" }]` | `raw.projects` | Array inside object |
+| `[{ "prop": "outputComponents", "index": 0 }, { "prop": "design" }, { "prop": "screens", "index": 0 }]` | `raw.outputComponents[0].design.screens[0]` | Deeply nested single item |
+| `[{ "prop": "outputComponents", "each": true }, { "prop": "design" }, { "prop": "screens", "each": true }]` | `flatMap` chain | Collect all items across arrays |
+| `[{ "prop": "screenshot" }, { "prop": "downloadUrl" }]` | `raw.screenshot.downloadUrl` | Navigate nested properties |
+
+**Decision**: Use `"index": 0` when extracting a single item. Use `"each": true` when collecting all items (array result). You **cannot** use both on the same step.
+
+> [!TIP]
+> Every `prop` in a projection is validated against the tool's `outputSchema` at codegen time. If you typo a property name, codegen will fail with a diagnostic listing the available properties.
+
+### Return class wrapping
+
+When `returns.class` is set, the extracted data is wrapped in a domain class constructor:
+```json
+{ "returns": { "class": "Screen", "projection": [{ "prop": "screens" }], "array": true } }
+```
+
+The codegen automatically spreads `parentField` into the data if the child class declares one.
+
+### Cache-aware methods
+
+Add a `cache` field with a structured `projection` to check `this.data` before calling the API:
+```json
+{
+  "cache": {
+    "projection": [{ "prop": "htmlCode" }, { "prop": "downloadUrl" }],
+    "description": "Use cached HTML download URL from generation response if available"
+  }
+}
+```
+
+When the cached property is a nested object (like `File` with a `downloadUrl`), use multiple projection steps to drill into it.
+
+Generated code:
+```typescript
+if (this.data?.htmlCode?.downloadUrl) return this.data?.htmlCode?.downloadUrl;
+// ... else call API
+```
+
+---
+
+## Decision Framework
+
+When mapping a new tool, answer these questions:
+
+1. **Which class?** Look at which fields the tool requires. If it needs `projectId` from `self`, it belongs on `Project` or `Screen`. If it needs nothing from self, it belongs on `Stitch`.
+
+2. **Which method name?** Use the verb from the tool name, simplified. `generate_screen_from_text` → `generate`. `edit_screens` → `edit`.
+
+3. **Arguments from self or param?** If the caller already has the data (because they're calling a method on themselves), use `self`. If they need to provide it, use `param`.
+
+4. **How deep is the return?** Check the tool's `outputSchema` in `tools-manifest.json`. Build the `projection` array step-by-step to navigate to the useful data.
+
+5. **Should it cache?** If the data is available from a previous response (like generation), add a cache field with the projection path.
+
+---
+
+## Validation
+
+After editing `domain-map.json`:
+
+```bash
+bun scripts/generate-sdk.ts     # Validates IR + projections, then generates
+npx tsc --noEmit                 # Type check
+npx vitest run                   # Unit tests
+bun scripts/e2e-test.ts          # E2E tests
+bun scripts/validate-generated.ts  # Lock integrity
+```
+
+If a projection is invalid, you'll see:
+```
+❌ Binding "Project.generate" projection step 2:
+   property "screenz" not found in outputSchema.
+   Available properties: screens, components, metadata
+```

--- a/.gemini/skills/stitch-sdk-pipeline/SKILL.md
+++ b/.gemini/skills/stitch-sdk-pipeline/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: stitch-sdk-pipeline
+description: Run the full Stitch SDK generation pipeline. Use when a new tool is added, or the SDK needs to be regenerated end-to-end.
+---
+
+# Stitch SDK Pipeline
+
+This skill orchestrates the full SDK generation pipeline — from capturing MCP tool schemas to publishing a tested, validated package. Use this when:
+
+- The Stitch MCP server adds or changes tools
+- You need to regenerate the SDK from scratch
+- You want to verify the pipeline is healthy
+
+> [!IMPORTANT]
+> **Stage 2 is the only step requiring agent intelligence.** All other stages are deterministic scripts. For Stage 2, use the `stitch-sdk-domain-design` skill.
+
+---
+
+## Prerequisites
+
+- `STITCH_API_KEY` environment variable set
+- `bun` installed
+- Working directory: project root (`stitch-sdk/`)
+
+---
+
+## Pipeline Stages
+
+### Stage 1: Capture Tool Schemas 🤖
+
+```bash
+// turbo
+npm run capture
+```
+
+Connects to the Stitch MCP server, calls `tools/list`, and writes the raw schemas to `core/generated/tools-manifest.json`. Updates the manifest section of `stitch-sdk.lock`.
+
+**Output**: `core/generated/tools-manifest.json` (includes `inputSchema` + `outputSchema` for every tool)
+
+**When to skip**: If `tools-manifest.json` is already up to date and no server-side changes occurred.
+
+---
+
+### Stage 2: Domain Design 🧠 (Agent)
+
+**Use the `stitch-sdk-domain-design` skill for this stage.**
+
+Read `tools-manifest.json` and edit `core/generated/domain-map.json` to map tools → classes → methods.
+
+Key decisions at this stage:
+- Which class owns each tool?
+- What are the arg routing rules (self, param, computed, selfArray)?
+- What is the response projection path?
+- Should the method cache data from the construction response?
+
+**Input**: `tools-manifest.json` + `scripts/ir-schema.ts` (the canonical IR contract)
+**Output**: `core/generated/domain-map.json`
+
+**When to skip**: If `domain-map.json` already has the correct bindings and you only changed `ir-schema.ts` or `generate-sdk.ts`.
+
+---
+
+### Stage 3: Generate TypeScript 🤖
+
+```bash
+// turbo
+npm run generate
+```
+
+Validates the IR (Zod schema) and every projection (against `outputSchema`), then emits TypeScript files via ts-morph into `core/generated/src/`.
+
+**Output**: `core/generated/src/*.ts` + updated `stitch-sdk.lock`
+
+If this fails with a projection error, go back to Stage 2 and fix `domain-map.json`.
+
+---
+
+### Stage 4: Build 🤖
+
+```bash
+// turbo
+npm run build
+```
+
+TypeScript compilation: `core/` → `core/dist/`.
+
+---
+
+### Stage 5: Unit Tests 🤖
+
+```bash
+// turbo
+npm run test
+```
+
+Runs core unit tests (vitest) — mocked `callTool`, verifying generated method signatures, caching, and error handling.
+
+---
+
+### Stage 6: Script Tests 🤖
+
+```bash
+// turbo
+npm run test:scripts
+```
+
+Runs contract tests (IR schema acceptance/rejection) and logic tests (expression builders) using `bun:test`.
+
+---
+
+### Stage 7: E2E Tests 🤖
+
+```bash
+npm run test:e2e
+```
+
+Live API tests against the built package. Requires `STITCH_API_KEY`. Tests create real projects, generate screens, and verify responses.
+
+---
+
+### Stage 8: Lock Validation 🤖
+
+```bash
+// turbo
+npm run validate:generated
+```
+
+Verifies that `stitch-sdk.lock` hashes match the actual generated files. Catches drift (someone edited generated files manually or forgot to regenerate).
+
+> [!IMPORTANT]
+> Always run **after** Stage 3 (Generate). If you run Capture (Stage 1) then Validate without re-generating, the hashes will mismatch because the manifest hash changed.
+
+---
+
+### Stage 9: Skill Audit 🧠 (Agent)
+
+After the pipeline passes, audit agent skills for freshness. Read the current source of truth and update any skills that reference stale methods, args, or examples.
+
+**Inputs**:
+- `core/src/index.ts` (public surface)
+- Generated class files in `core/generated/src/`
+- `core/src/spec/errors.ts` (error codes)
+- `core/src/spec/client.ts` (config schema)
+
+**Skills to audit** (in priority order):
+1. `stitch-sdk-usage` — highest churn, references specific methods and constructor signatures
+2. `stitch-sdk-development` — check cache examples match current domain-map patterns
+3. `stitch-sdk-domain-design` — check code examples in the cache section
+
+**Skills to skip**: `stitch-sdk-readme` (template-based, doesn't enumerate methods), `stitch-sdk-pipeline` (self-referential), `red-green-yellow` (generic methodology).
+
+**What to check**:
+- Every method name in a code example exists on its class
+- Every import in an example matches an export in `index.ts`
+- Constructor signatures match the actual constructors
+- Config fields match `StitchConfigSchema`
+- Error codes match `StitchErrorCode`
+
+**When to skip**: If only infrastructure code changed (`core/src/client.ts`, `core/src/proxy/`) and no public API surface changed.
+
+---
+
+## Quick Reference
+
+### Full pipeline (script stages only)
+
+```bash
+npm run pipeline
+```
+
+Runs Stage 1 → 3 → 4 → 5 in sequence. Does **not** include Stage 2 (agent), Stage 7 (e2e), or Stage 9 (skill audit).
+
+### Starting from a specific stage
+
+| Scenario | Start from |
+|---|---|
+| New tool added to MCP server | Stage 1 |
+| Need to change how a tool maps to a method | Stage 2 |
+| Changed `ir-schema.ts` or `generate-sdk.ts` | Stage 3 |
+| Changed code in `core/src/` (client, errors) | Stage 4 |
+| Just want to verify everything works | Stage 5 |
+| Public API surface changed | Stage 9 |
+
+### Key files
+
+| File | Location | Role |
+|---|---|---|
+| `tools-manifest.json` | `core/generated/` | Raw MCP tool schemas (Stage 1 output) |
+| `domain-map.json` | `core/generated/` | IR: tool → class → method mappings (Stage 2 output) |
+| `ir-schema.ts` | `scripts/` | Zod schema defining valid IR structure |
+| `tool-schema.ts` | `scripts/` | TypeScript types for JSON Schema |
+| `generate-sdk.ts` | `scripts/` | ts-morph codegen (Stage 3) |
+| `stitch-sdk.lock` | `core/generated/` | Integrity hashes for drift detection |

--- a/.gemini/skills/stitch-sdk-usage/SKILL.md
+++ b/.gemini/skills/stitch-sdk-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stitch-sdk-usage
-description: Use the Stitch SDK to generate UI screens from text prompts, manage projects, and retrieve screen HTML/images. Use when the user wants to consume the SDK in their application.
+description: Use the Stitch SDK to generate, edit, and iterate on UI screens from text prompts, manage projects, and retrieve screen HTML/images. Use when the user wants to consume the SDK in their application.
 ---
 
 # Using the Stitch SDK
@@ -24,130 +24,153 @@ export STITCH_API_KEY="your-api-key"
 ```typescript
 import { stitch } from '@google/stitch-sdk';
 
-// Connect to Stitch
-await stitch.connect();
-
-// List all projects
-const projectsResult = await stitch.projects();
-if (projectsResult.success) {
-  console.log(projectsResult.data);
-}
+const project = await stitch.createProject("My App");
+const screen = await project.generate("A settings page with dark theme");
+const html = await screen.getHtml();     // download URL for the HTML
+const imageUrl = await screen.getImage(); // download URL for the screenshot
 ```
 
-## Result Type
-
-All SDK operations return a `Result<T>` type:
-
-```typescript
-type Result<T> =
-  | { success: true; data: T }
-  | { success: false; error: StitchError };
-```
-
-**Always check `result.success` before accessing `result.data`:**
-
-```typescript
-const result = await stitch.projects();
-if (result.success) {
-  for (const project of result.data) {
-    console.log(project.id);
-  }
-} else {
-  console.error(result.error.message);
-}
-```
+The `stitch` singleton reads `STITCH_API_KEY` from the environment and connects on first use — no setup code required.
 
 ## Working with Projects
 
 ```typescript
-// List all projects
-const projectsResult = await stitch.projects();
+import { stitch } from '@google/stitch-sdk';
 
-// Access a specific project by ID
-const projectResult = stitch.project("project-id");
+// List all projects
+const projects = await stitch.projects();
+
+// Reference a project by ID (no network call)
+const project = stitch.project("4044680601076201931");
 
 // Create a new project
-const createResult = await stitch.createProject("My App");
+const newProject = await stitch.createProject("My App");
 ```
 
-## Generating Screens
+## Generating and Iterating on Screens
 
 ```typescript
-const projectResult = stitch.project("project-id");
-if (!projectResult.success) return;
-const project = projectResult.data;
-
 // Generate a new screen from a prompt
-const screenResult = await project.generate(
-  "Login page with email and password fields",
-  "DESKTOP"  // or "MOBILE"
-);
+const screen = await project.generate("Login page with email and password fields");
 
-if (screenResult.success) {
-  const screen = screenResult.data;
-  console.log(`Generated screen: ${screen.id}`);
-}
+// Edit an existing screen
+const edited = await screen.edit("Make the background dark and add a subtitle");
+
+// Generate variants of a screen
+const variants = await screen.variants("Try different color schemes", {
+  variantCount: 2,
+  creativeRange: "EXPLORE",
+  aspects: ["COLOR_SCHEME", "LAYOUT"],
+});
 ```
 
 ## Retrieving Screen Assets
 
 ```typescript
-// Get screen HTML
-const htmlResult = await screen.getHtml();
-if (htmlResult.success) {
-  console.log(htmlResult.data); // Raw HTML string
-}
+// Get screen HTML download URL
+const html = await screen.getHtml();
 
-// Get screen image URL
-const imageResult = await screen.getImage();
-if (imageResult.success) {
-  console.log(imageResult.data); // Image URL
+// Get screen screenshot download URL
+const imageUrl = await screen.getImage();
+```
+
+Both methods use cached data from the generation response when available, falling back to an API call when needed.
+
+## Dynamic Tool Client (for agents)
+
+For agents and orchestration scripts that forward JSON payloads to MCP tools:
+
+```typescript
+import { StitchToolClient } from '@google/stitch-sdk';
+
+const client = new StitchToolClient(); // reads STITCH_API_KEY from env
+const tools = await client.listTools();
+const result = await client.callTool("generate_screen_from_text", {
+  projectId: "123", prompt: "A login page"
+});
+await client.close();
+```
+
+## Error Handling
+
+All SDK methods throw `StitchError` on failure. Use try/catch:
+
+```typescript
+import { stitch, StitchError } from '@google/stitch-sdk';
+
+try {
+  const project = stitch.project("bad-id");
+  await project.screens();
+} catch (e) {
+  if (e instanceof StitchError) {
+    console.log(e.code);        // "AUTH_FAILED", "NOT_FOUND", etc.
+    console.log(e.message);     // Human-readable description
+    console.log(e.recoverable); // Whether retrying might succeed
+  }
 }
 ```
+
+Error codes: `AUTH_FAILED`, `NOT_FOUND`, `PERMISSION_DENIED`, `RATE_LIMITED`, `NETWORK_ERROR`, `VALIDATION_ERROR`, `UNKNOWN_ERROR`
 
 ## API Reference
 
 ### Stitch Class
 
 | Method | Returns | Description |
-|--------|---------|-------------|
-| `connect()` | `Promise<Result<void>>` | Connect to the Stitch MCP server |
-| `projects()` | `Promise<Result<Project[]>>` | List all projects |
-| `project(id)` | `Result<Project>` | Get a project wrapper by ID |
-| `createProject(title)` | `Promise<Result<Project>>` | Create a new project |
+|---|---|---|
+| `createProject(title)` | `Promise<Project>` | Create a new project |
+| `projects()` | `Promise<Project[]>` | List all projects |
+| `project(id)` | `Project` | Reference a project by ID (no network call) |
 
 ### Project Class
 
 | Method | Returns | Description |
-|--------|---------|-------------|
-| `generate(prompt, deviceType?)` | `Promise<Result<Screen>>` | Generate a screen from a text prompt |
-| `screens()` | `Promise<Result<Screen[]>>` | List all screens in the project |
+|---|---|---|
+| `generate(prompt, deviceType?)` | `Promise<Screen>` | Generate a screen from a text prompt |
+| `screens()` | `Promise<Screen[]>` | List all screens in the project |
+| `getScreen(screenId)` | `Promise<Screen>` | Retrieve a specific screen by ID |
+
+`deviceType`: `"MOBILE"` | `"DESKTOP"` | `"TABLET"` | `"AGNOSTIC"`
 
 ### Screen Class
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `id` | `string` | Screen identifier |
-| `projectId` | `string` | Parent project ID |
+| Method | Returns | Description |
+|---|---|---|
+| `getHtml()` | `Promise<string>` | Get the screen's HTML download URL |
+| `getImage()` | `Promise<string>` | Get the screen's screenshot download URL |
+| `edit(prompt, deviceType?, modelId?)` | `Promise<Screen>` | Edit the screen using a text prompt |
+| `variants(prompt, options, deviceType?, modelId?)` | `Promise<Screen[]>` | Generate variants of the screen |
+
+`modelId`: `"GEMINI_3_PRO"` | `"GEMINI_3_FLASH"`
+
+### StitchToolClient (for agents)
 
 | Method | Returns | Description |
-|--------|---------|-------------|
-| `getHtml()` | `Promise<Result<string>>` | Fetch the screen's HTML code |
-| `getImage()` | `Promise<Result<string>>` | Fetch the screen's image URL |
+|---|---|---|
+| `callTool(name, args)` | `Promise<T>` | Call any MCP tool by name |
+| `listTools()` | `Promise<Tools>` | Discover available tools |
+| `connect()` | `Promise<void>` | Establish MCP connection (auto-called by callTool) |
+| `close()` | `Promise<void>` | Close the connection |
 
-## Error Handling
+### Explicit Configuration
 
 ```typescript
-const result = await stitch.projects();
-if (!result.success) {
-  if (result.error.code === 'AUTH_ERROR') {
-    console.error('Check your STITCH_API_KEY');
-  } else if (result.error.recoverable) {
-    // Retry logic
-  } else {
-    throw new Error(result.error.message);
-  }
-}
+import { Stitch, StitchToolClient } from '@google/stitch-sdk';
+
+const client = new StitchToolClient({
+  apiKey: "your-api-key",
+  baseUrl: "https://stitch.googleapis.com/mcp",
+  timeout: 300_000,
+});
+
+const sdk = new Stitch(client);
+const projects = await sdk.projects();
 ```
 
-Error codes: `NETWORK_ERROR`, `AUTH_ERROR`, `NOT_FOUND`, `VALIDATION_ERROR`, `UNKNOWN_ERROR`
+| Option | Env Variable | Description |
+|---|---|---|
+| `apiKey` | `STITCH_API_KEY` | API key for authentication |
+| `accessToken` | `STITCH_ACCESS_TOKEN` | OAuth access token |
+| `projectId` | `GOOGLE_CLOUD_PROJECT` | GCP project ID (required with OAuth) |
+| `baseUrl` | — | MCP server URL (default: `https://stitch.googleapis.com/mcp`) |
+| `timeout` | — | Request timeout in ms (default: 300000) |


### PR DESCRIPTION
- Add Stage 9 agent-driven skill audit to stitch-sdk-pipeline
- Rewrite stitch-sdk-usage: fix constructor (Stitch(client) not config), remove nonexistent Stitch.connect(), fix variants args (variantCount), add getScreen, correct getHtml/getImage descriptions, add client.close()
- Update cache examples in domain-design and development skills to show multi-step projection for File objects (htmlCode.downloadUrl)
- Add red-green-yellow TDD skill