### PR TITLE
chore: npm publish readiness

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,265 @@
+# @google/stitch-sdk
+
+Generate UI screens from text prompts and extract their HTML and screenshots programmatically.
+
+## Quick Start
+
+Set your API key and generate a screen:
+
+```ts
+import { stitch } from "@google/stitch-sdk";
+
+// STITCH_API_KEY must be set in the environment
+const project = await stitch.createProject("My App");
+const screen = await project.generate("A login page with email and password fields");
+const html = await screen.getHtml();
+const imageUrl = await screen.getImage();
+```
+
+`html` is a download URL for the screen's HTML. `imageUrl` is a download URL for the screenshot.
+
+## Install
+
+```bash
+npm install @google/stitch-sdk
+```
+
+## Working with Projects and Screens
+
+### List existing projects
+
+```ts
+import { stitch } from "@google/stitch-sdk";
+
+const projects = await stitch.projects();
+for (const project of projects) {
+  console.log(project.id, project.projectId);
+  const screens = await project.screens();
+  console.log(`  ${screens.length} screens`);
+}
+```
+
+### Reference a project by ID
+
+If you already have a project ID, reference it directly:
+
+```ts
+const project = stitch.project("4044680601076201931");
+// Call methods on it — each method fetches data as needed
+const screens = await project.screens();
+```
+
+### Edit a screen
+
+```ts
+const screen = await project.generate("A dashboard with charts");
+const edited = await screen.edit("Make the background dark and add a sidebar");
+const editedHtml = await edited.getHtml();
+```
+
+### Generate variants
+
+```ts
+const variants = await screen.variants("Try different color schemes", {
+  variantCount: 3,
+  creativeRange: "EXPLORE",
+  aspects: ["COLOR_SCHEME", "LAYOUT"],
+});
+
+for (const variant of variants) {
+  console.log(variant.id, await variant.getHtml());
+}
+```
+
+`variantOptions` fields:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `variantCount` | `number` | 3 | Number of variants (1–5) |
+| `creativeRange` | `string` | `"EXPLORE"` | `"REFINE"`, `"EXPLORE"`, or `"REIMAGINE"` |
+| `aspects` | `string[]` | all | `"LAYOUT"`, `"COLOR_SCHEME"`, `"IMAGES"`, `"TEXT_FONT"`, `"TEXT_CONTENT"` |
+
+## Tool Client (Agent Usage)
+
+For agents and orchestration scripts that need direct MCP tool access:
+
+```ts
+import { StitchToolClient } from "@google/stitch-sdk";
+
+const client = new StitchToolClient({ apiKey: "your-api-key" });
+
+// List available tools
+const { tools } = await client.listTools();
+for (const tool of tools) {
+  console.log(tool.name, tool.description);
+}
+
+// Call a tool directly
+const result = await client.callTool("create_project", {
+  title: "Agent Project",
+});
+
+await client.close();
+```
+
+The client auto-connects on the first `callTool` or `listTools` call. No explicit `connect()` needed.
+
+## API Reference
+
+### `Stitch`
+
+The root class. Manages projects.
+
+| Method | Parameters | Returns | Description |
+|---|---|---|---|
+| `createProject(title)` | `title: string` | `Promise<Project>` | Create a new project |
+| `projects()` | — | `Promise<Project[]>` | List all accessible projects |
+| `project(id)` | `id: string` | `Project` | Reference a project by ID (no API call) |
+
+### `Project`
+
+A Stitch project containing screens.
+
+| Property | Type | Description |
+|---|---|---|
+| `id` | `string` | Alias for `projectId` |
+| `projectId` | `string` | Bare project ID (no `projects/` prefix) |
+
+| Method | Parameters | Returns | Description |
+|---|---|---|---|
+| `generate(prompt, deviceType?)` | `prompt: string`, `deviceType?: DeviceType` | `Promise<Screen>` | Generate a screen from a text prompt |
+| `screens()` | — | `Promise<Screen[]>` | List all screens in the project |
+| `getScreen(screenId)` | `screenId: string` | `Promise<Screen>` | Retrieve a specific screen by ID |
+
+`DeviceType`: `"MOBILE"` \| `"DESKTOP"` \| `"TABLET"` \| `"AGNOSTIC"`
+
+### `Screen`
+
+A generated UI screen. Provides access to HTML and screenshots.
+
+| Property | Type | Description |
+|---|---|---|
+| `id` | `string` | Alias for `screenId` |
+| `screenId` | `string` | Bare screen ID |
+| `projectId` | `string` | Parent project ID |
+
+| Method | Parameters | Returns | Description |
+|---|---|---|---|
+| `edit(prompt, deviceType?, modelId?)` | `prompt: string` | `Promise<Screen>` | Edit the screen with a text prompt |
+| `variants(prompt, variantOptions, deviceType?, modelId?)` | `prompt: string`, `variantOptions: object` | `Promise<Screen[]>` | Generate design variants |
+| `getHtml()` | — | `Promise<string>` | Get the screen's HTML download URL |
+| `getImage()` | — | `Promise<string>` | Get the screen's screenshot download URL |
+
+`getHtml()` and `getImage()` use cached data from the generation response when available. If the screen was loaded from `screens()` or `getScreen()`, they call the `get_screen` API automatically.
+
+`modelId`: `"GEMINI_3_PRO"` \| `"GEMINI_3_FLASH"`
+
+### `StitchToolClient`
+
+Low-level authenticated pipe to the Stitch MCP server. Use this when you need direct tool access (e.g., in an AI agent).
+
+```ts
+const client = new StitchToolClient({ apiKey: "..." });
+const result = await client.callTool<any>("tool_name", { arg: "value" });
+await client.close();
+```
+
+| Method | Parameters | Returns | Description |
+|---|---|---|---|
+| `callTool<T>(name, args)` | `name: string`, `args: Record<string, any>` | `Promise<T>` | Call an MCP tool |
+| `listTools()` | — | `Promise<{ tools }>` | List available tools |
+| `connect()` | — | `Promise<void>` | Explicitly connect (auto-called by `callTool`) |
+| `close()` | — | `Promise<void>` | Close the connection |
+
+### `StitchProxy`
+
+An MCP proxy server that forwards requests to Stitch. Use this to expose Stitch tools through your own MCP server.
+
+```ts
+import { StitchProxy } from "@google/stitch-sdk";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+const proxy = new StitchProxy({ apiKey: "..." });
+const transport = new StdioServerTransport();
+await proxy.start(transport);
+```
+
+### `stitch` Singleton
+
+A pre-configured `Stitch` instance that reads `STITCH_API_KEY` from the environment. Lazily initialized on first use.
+
+```ts
+import { stitch } from "@google/stitch-sdk";
+
+// No setup needed — just use it
+const projects = await stitch.projects();
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `STITCH_API_KEY` | Yes (or use OAuth) | API key for authentication |
+| `STITCH_ACCESS_TOKEN` | No | OAuth access token (alternative to API key) |
+| `GOOGLE_CLOUD_PROJECT` | With OAuth | Google Cloud project ID |
+| `STITCH_HOST` | No | Override the MCP server URL |
+
+### Explicit Configuration
+
+```ts
+import { Stitch, StitchToolClient } from "@google/stitch-sdk";
+
+const client = new StitchToolClient({
+  apiKey: "your-api-key",
+  baseUrl: "https://stitch.googleapis.com/mcp",
+  timeout: 300_000,
+});
+
+const sdk = new Stitch(client);
+const projects = await sdk.projects();
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `apiKey` | `string` | `STITCH_API_KEY` | API key |
+| `accessToken` | `string` | `STITCH_ACCESS_TOKEN` | OAuth token |
+| `projectId` | `string` | `GOOGLE_CLOUD_PROJECT` | Cloud project ID |
+| `baseUrl` | `string` | `https://stitch.googleapis.com/mcp` | MCP server URL |
+| `timeout` | `number` | `300000` | Request timeout (ms) |
+
+Authentication requires either `apiKey` or both `accessToken` and `projectId`.
+
+## Error Handling
+
+All domain class methods throw `StitchError` on failure:
+
+```ts
+import { stitch, StitchError } from "@google/stitch-sdk";
+
+try {
+  const project = stitch.project("bad-id");
+  await project.screens();
+} catch (error) {
+  if (error instanceof StitchError) {
+    console.error(error.code);        // "UNKNOWN_ERROR"
+    console.error(error.message);     // Human-readable description
+    console.error(error.recoverable); // false
+  }
+}
+```
+
+Error codes: `AUTH_FAILED`, `NOT_FOUND`, `PERMISSION_DENIED`, `RATE_LIMITED`, `NETWORK_ERROR`, `VALIDATION_ERROR`, `UNKNOWN_ERROR`.
+
+---
+
+## Disclaimer
+
+This is not an officially supported Google product. This project is not
+eligible for the [Google Open Source Software Vulnerability Rewards
+Program](https://bughunters.google.com/open-source-security).
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE) for details.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,9 +2,39 @@
   "name": "@google/stitch-sdk",
   "version": "0.0.1",
   "type": "module",
-  "description": "The foundational SDK and MCP Client for Stitch",
+  "description": "Generate UI screens from text prompts and extract their HTML and screenshots programmatically.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/stitch-sdk.git",
+    "directory": "packages/sdk"
+  },
+  "keywords": [
+    "stitch",
+    "mcp",
+    "ui",
+    "generative-ai",
+    "google"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/src/index.js",
+      "types": "./dist/src/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com",
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/scripts/publish-readiness.ts
+++ b/scripts/publish-readiness.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env bun
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Publish Readiness Check
+ *
+ * Automated verification that the SDK package is ready for npm publish.
+ * Run: bun scripts/publish-readiness.ts
+ *
+ * Checks:
+ *   1. Build succeeds (tsc)
+ *   2. Entry points exist (main, types, exports)
+ *   3. Package metadata is complete
+ *   4. Pack contents are clean (no source, no tests)
+ *   5. Pack size is reasonable
+ *   6. Consumer import works (pack → install → import)
+ *   7. Unit tests pass
+ */
+
+import { resolve } from "node:path";
+import { existsSync, mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import assert from "node:assert";
+
+const ROOT_DIR = resolve(import.meta.dir, "..");
+const SDK_DIR = resolve(ROOT_DIR, "packages/sdk");
+
+let passed = 0;
+let failed = 0;
+
+function check(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } catch (e: any) {
+    console.log(`  ❌ ${name}`);
+    console.log(`     ${e.message}`);
+    failed++;
+  }
+}
+
+// ── 1. Build ────────────────────────────────────────────────────────────────
+console.log("\n🔨 Build");
+check("tsc compiles without errors", () => {
+  execSync("npm run build", { cwd: SDK_DIR, stdio: "pipe" });
+});
+
+// ── 2. Entry Points ─────────────────────────────────────────────────────────
+console.log("\n📦 Entry Points");
+const pkg = JSON.parse(readFileSync(resolve(SDK_DIR, "package.json"), "utf8"));
+
+check(`main exists: ${pkg.main}`, () => {
+  assert(existsSync(resolve(SDK_DIR, pkg.main)), `${pkg.main} not found`);
+});
+
+check(`types exists: ${pkg.types}`, () => {
+  assert(existsSync(resolve(SDK_DIR, pkg.types)), `${pkg.types} not found`);
+});
+
+if (pkg.exports) {
+  for (const [key, value] of Object.entries(pkg.exports)) {
+    const exp = value as any;
+    if (exp.import) {
+      check(`exports["${key}"].import exists: ${exp.import}`, () => {
+        assert(existsSync(resolve(SDK_DIR, exp.import)), `${exp.import} not found`);
+      });
+    }
+    if (exp.types) {
+      check(`exports["${key}"].types exists: ${exp.types}`, () => {
+        assert(existsSync(resolve(SDK_DIR, exp.types)), `${exp.types} not found`);
+      });
+    }
+  }
+}
+
+// ── 3. Package Metadata ─────────────────────────────────────────────────────
+console.log("\n📋 Package Metadata");
+const requiredFields = ["name", "version", "description", "license", "main", "types", "files", "exports"];
+for (const field of requiredFields) {
+  check(`"${field}" is set`, () => {
+    assert(pkg[field] !== undefined, `Missing "${field}" in package.json`);
+  });
+}
+
+check('"license" is Apache-2.0', () => {
+  assert.strictEqual(pkg.license, "Apache-2.0", `Expected Apache-2.0, got ${pkg.license}`);
+});
+
+check('"type" is "module"', () => {
+  assert.strictEqual(pkg.type, "module", `Expected "module", got ${pkg.type}`);
+});
+
+check("README.md exists in package dir", () => {
+  assert(existsSync(resolve(SDK_DIR, "README.md")), "README.md not found in packages/sdk/");
+});
+
+// ── 4. Pack Contents ────────────────────────────────────────────────────────
+console.log("\n📦 Pack Contents");
+const packOutput = execSync("npm pack --dry-run --json 2>/dev/null", {
+  cwd: SDK_DIR,
+  encoding: "utf8",
+});
+const packData = JSON.parse(packOutput);
+const packFiles: { path: string; size: number }[] = packData[0].files;
+const packFileNames = packFiles.map((f) => f.path);
+
+check("no .ts source files in pack", () => {
+  const tsFiles = packFileNames.filter(
+    (f) => f.endsWith(".ts") && !f.endsWith(".d.ts") && f !== "package.json"
+  );
+  assert.strictEqual(tsFiles.length, 0, `Found .ts source files: ${tsFiles.join(", ")}`);
+});
+
+check("no test files in pack", () => {
+  const testFiles = packFileNames.filter((f) => f.includes("test/") || f.includes(".test."));
+  assert.strictEqual(testFiles.length, 0, `Found test files: ${testFiles.join(", ")}`);
+});
+
+check("no generated source (.ts) in pack", () => {
+  const genTs = packFileNames.filter(
+    (f) => f.includes("generated/") && f.endsWith(".ts") && !f.endsWith(".d.ts")
+  );
+  assert.strictEqual(genTs.length, 0, `Found generated .ts: ${genTs.join(", ")}`);
+});
+
+check("no tools-manifest.json in pack", () => {
+  const manifest = packFileNames.filter((f) => f.includes("tools-manifest"));
+  assert.strictEqual(manifest.length, 0, `Found manifest: ${manifest.join(", ")}`);
+});
+
+check("dist/ files are present", () => {
+  const distFiles = packFileNames.filter((f) => f.startsWith("dist/"));
+  assert(distFiles.length > 0, "No dist/ files in pack");
+});
+
+// ── 5. Pack Size ────────────────────────────────────────────────────────────
+console.log("\n📐 Pack Size");
+const totalSize = packData[0].unpackedSize;
+const totalKB = Math.round(totalSize / 1024);
+
+check(`pack size is reasonable (${totalKB} KB, limit: 250 KB)`, () => {
+  assert(totalSize < 250 * 1024, `Pack is ${totalKB} KB — too large for a library`);
+});
+
+const fileCount = packFiles.length;
+check(`file count is reasonable (${fileCount} files, limit: 200)`, () => {
+  assert(fileCount < 200, `${fileCount} files in pack — too many`);
+});
+
+// ── 6. Consumer Import ──────────────────────────────────────────────────────
+console.log("\n🧪 Consumer Import");
+let tempDir: string | null = null;
+
+check("npm pack → install → import works", () => {
+  // Pack
+  const tarball = execSync("npm pack 2>/dev/null", {
+    cwd: SDK_DIR,
+    encoding: "utf8",
+  }).trim();
+  const tarballPath = resolve(SDK_DIR, tarball);
+
+  // Create temp project
+  tempDir = mkdtempSync(resolve(tmpdir(), "stitch-sdk-test-"));
+  execSync('npm init -y 2>/dev/null && npm pkg set type="module"', {
+    cwd: tempDir,
+    stdio: "pipe",
+  });
+
+  // Install from tarball
+  execSync(`npm install ${tarballPath} 2>/dev/null`, {
+    cwd: tempDir,
+    stdio: "pipe",
+  });
+
+  // Test import
+  const testScript = `
+    import { stitch, Stitch, Project, Screen, StitchError } from "@google/stitch-sdk";
+
+    // Verify exports exist
+    if (typeof Stitch !== "function") throw new Error("Stitch class not exported");
+    if (typeof Project !== "function") throw new Error("Project class not exported");
+    if (typeof Screen !== "function") throw new Error("Screen class not exported");
+    if (typeof StitchError !== "function") throw new Error("StitchError class not exported");
+
+    console.log("All exports verified ✓");
+  `;
+
+  const { writeFileSync } = require("fs");
+  writeFileSync(resolve(tempDir, "test.mjs"), testScript);
+
+  execSync("node test.mjs", {
+    cwd: tempDir,
+    stdio: "pipe",
+    env: { ...process.env, STITCH_API_KEY: "test-key-for-import-check" },
+  });
+
+  // Clean up tarball
+  rmSync(tarballPath, { force: true });
+});
+
+// Clean up temp dir
+if (tempDir) {
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+// ── 7. Unit Tests ───────────────────────────────────────────────────────────
+console.log("\n🧪 Unit Tests");
+check("vitest passes", () => {
+  execSync("npx vitest run", { cwd: SDK_DIR, stdio: "pipe" });
+});
+
+// ── Summary ─────────────────────────────────────────────────────────────────
+console.log(`\n${"─".repeat(60)}`);
+if (failed === 0) {
+  console.log(`\n✅ All ${passed} checks passed. Ready to publish.`);
+} else {
+  console.log(`\n💥 ${failed} check(s) failed, ${passed} passed.`);
+  console.log("   Fix the issues above before publishing.");
+  process.exit(1);
+}


### PR DESCRIPTION
- Add license (Apache-2.0), repository, keywords, engines
- Add exports map (top-level only)
- Add files whitelist (dist + README only)
- Copy README.md to packages/sdk/
- Build verification
- Entry point existence (main, types, exports)
- Metadata completeness (8 required fields)
- Pack contents cleanliness (no source, no tests, no manifest)
- Pack size validation (202 KB / 148 files)
- Consumer import test (npm pack → install → import)
- Unit test pass-through