### PR TITLE
refactor: remove createProject — pure identity map pattern

### DIFF
--- a/.agents/skills/stitch-sdk-readme/SKILL.md
+++ b/.agents/skills/stitch-sdk-readme/SKILL.md
@@ -49,9 +49,9 @@ Immediately show the library in use. Code first, not setup.
 
 **Primary workflow** — the punchline everything in the SDK exists to produce:
 ```
-createProject → generate → getHtml
+project(id) → generate → getHtml
 ```
-Show this as the first code block, with one line noting the env var requirement. Do not show installation, imports, or config before this.
+Show this as the first code block, with one line noting the env var requirement. Do not show installation, imports, or config before this. Show `callTool("create_project", ...)` separately for project creation.
 
 **Secondary workflows** — reveal depth progressively:
 1. Listing and iterating over existing projects/screens

--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ Set your API key and generate a screen:
 import { stitch } from "@google/stitch-sdk";
 
 // STITCH_API_KEY must be set in the environment
-const project = await stitch.createProject("My App");
+const project = stitch.project("your-project-id");
 const screen = await project.generate("A login page with email and password fields");
 const html = await screen.getHtml();
 const imageUrl = await screen.getImage();
 ```
 
 `html` is a download URL for the screen's HTML. `imageUrl` is a download URL for the screenshot.
+
+Need to create a project first? Use the tool client:
+
+```ts
+const result = await stitch.callTool("create_project", { title: "My App" });
+```
 
 ## Install
 
@@ -147,7 +153,6 @@ The root class. Manages projects.
 
 | Method | Parameters | Returns | Description |
 |---|---|---|---|
-| `createProject(title)` | `title: string` | `Promise<Project>` | Create a new project |
 | `projects()` | — | `Promise<Project[]>` | List all accessible projects |
 | `project(id)` | `id: string` | `Project` | Reference a project by ID (no API call) |
 

--- a/packages/sdk/generated/domain-map.json
+++ b/packages/sdk/generated/domain-map.json
@@ -48,20 +48,6 @@
   },
   "bindings": [
     {
-      "tool": "create_project",
-      "class": "Stitch",
-      "method": "createProject",
-      "args": {
-        "title": {
-          "from": "param"
-        }
-      },
-      "returns": {
-        "class": "Project",
-        "projection": []
-      }
-    },
-    {
       "tool": "list_projects",
       "class": "Stitch",
       "method": "projects",

--- a/packages/sdk/generated/src/index.ts
+++ b/packages/sdk/generated/src/index.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:a8c87655b83c...)
-Generated: 2026-03-07T18:51:17.154Z
+        domain-map.json     (sha256:efa6858b5d46...)
+Generated: 2026-03-08T00:44:24.555Z
  */
 export { Stitch } from "./stitch.js";
 export { Project } from "./project.js";

--- a/packages/sdk/generated/src/project.ts
+++ b/packages/sdk/generated/src/project.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:a8c87655b83c...)
-Generated: 2026-03-07T18:51:17.154Z
+        domain-map.json     (sha256:efa6858b5d46...)
+Generated: 2026-03-08T00:44:24.555Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/screen.ts
+++ b/packages/sdk/generated/src/screen.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:a8c87655b83c...)
-Generated: 2026-03-07T18:51:17.154Z
+        domain-map.json     (sha256:efa6858b5d46...)
+Generated: 2026-03-08T00:44:24.555Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/stitch.ts
+++ b/packages/sdk/generated/src/stitch.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:a8c87655b83c...)
-Generated: 2026-03-07T18:51:17.154Z
+        domain-map.json     (sha256:efa6858b5d46...)
+Generated: 2026-03-08T00:44:24.555Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";
@@ -13,19 +13,6 @@ import { Project } from "./project.js";
 /** Main entry point. Manages projects. */
 export class Stitch {
     constructor(private client: StitchToolClient) {
-    }
-
-    /**
-     * Creates a new Stitch project. A project is a container for UI designs and frontend code.
-     * Tool: create_project
-     */
-    async createProject(title: string): Promise<Project> {
-        try {
-          const raw = await this.client.callTool<any>("create_project", { title });
-          return new Project(this.client, raw);
-        } catch (error) {
-          throw StitchError.fromUnknown(error);
-        }
     }
 
     /**

--- a/packages/sdk/generated/src/tool-definitions.ts
+++ b/packages/sdk/generated/src/tool-definitions.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:a8c87655b83c...)
-Generated: 2026-03-07T18:51:17.154Z
+        domain-map.json     (sha256:efa6858b5d46...)
+Generated: 2026-03-08T00:44:24.555Z
  */
 /** Static tool definition from the Stitch MCP server manifest. */
 export interface ToolDefinition {

--- a/packages/sdk/generated/stitch-sdk.lock
+++ b/packages/sdk/generated/stitch-sdk.lock
@@ -7,17 +7,17 @@
     "serverUrl": "https://stitch.googleapis.com/mcp"
   },
   "generated": {
-    "generatedAt": "2026-03-07T18:51:17.229Z",
-    "sourceHash": "sha256:c63309d4ea3bb44fd1fcceadb839d467348fc013ebdc259c5b9e62e504cd9f74",
+    "generatedAt": "2026-03-08T00:44:24.632Z",
+    "sourceHash": "sha256:e1a11b9665e74c38dbb455b8b85a4e4604142cf7baa2005719e55ccc11920000",
     "manifestHash": "sha256:1f84b31604f95580325952f0c150a3e045543fad2596e9a4d8ed15c07e0cbf9b",
-    "domainMapHash": "sha256:a8c87655b83cf6010f174b762dadb0a5e3b340fc401c528ddfa3e14d44deee36",
+    "domainMapHash": "sha256:efa6858b5d46f8509d810a816b9cab87f1b3e33b3c8be84d973346181dd6d134",
     "fileCount": 5
   },
   "domainMap": {
-    "generatedAt": "2026-03-07T18:51:17.229Z",
-    "sourceHash": "sha256:a8c87655b83cf6010f174b762dadb0a5e3b340fc401c528ddfa3e14d44deee36",
+    "generatedAt": "2026-03-08T00:44:24.632Z",
+    "sourceHash": "sha256:efa6858b5d46f8509d810a816b9cab87f1b3e33b3c8be84d973346181dd6d134",
     "manifestHash": "sha256:1f84b31604f95580325952f0c150a3e045543fad2596e9a4d8ed15c07e0cbf9b",
     "classCount": 3,
-    "bindingCount": 9
+    "bindingCount": 8
   }
 }

--- a/packages/sdk/test/integration/live.test.ts
+++ b/packages/sdk/test/integration/live.test.ts
@@ -35,9 +35,17 @@ runIfConfigured("Stitch Live Integration", () => {
     }
   });
 
-  it("should create and retrieve a project", async () => {
-    const project = await sdk.createProject(`Test Project ${Date.now()}`);
-    expect(project.id).toContain("projects/");
-    console.log("Created Project:", project.id);
+  it("should create and retrieve a project via callTool + identity map", async () => {
+    const client = new StitchToolClient();
+    await client.connect();
+    const result = await client.callTool<any>("create_project", { title: `Test Project ${Date.now()}` });
+    const projectId = result.name?.replace("projects/", "") ?? result.projectId;
+    expect(projectId).toBeDefined();
+
+    const project = sdk.project(projectId);
+    expect(project.id).toBe(projectId);
+    const screens = await project.screens();
+    expect(Array.isArray(screens)).toBe(true);
+    console.log("Created & retrieved project via identity map:", project.id);
   }, 30000);
 });

--- a/packages/sdk/test/unit/sdk.test.ts
+++ b/packages/sdk/test/unit/sdk.test.ts
@@ -153,6 +153,11 @@ describe("SDK Unit Tests", () => {
       expect(typeof (sdk as any).getProject).toBe("undefined");
     });
 
+    it("should not have a createProject method — use callTool or stitchTools() instead", () => {
+      const sdk = new Stitch(mockClient);
+      expect(typeof (sdk as any).createProject).toBe("undefined");
+    });
+
     it("project(id) should return a Project handle with correct ID", () => {
       const sdk = new Stitch(mockClient);
       const handle = sdk.project("proj-123");

--- a/scripts/e2e-test.ts
+++ b/scripts/e2e-test.ts
@@ -55,22 +55,20 @@ try {
   const projects = await stitch.projects();
   assert(Array.isArray(projects), `Listed ${projects.length} projects`);
 
-  // ── 2. Create project ───────────────────────────────────────
-  console.log("\n📦 Creating project...");
+  // ── 2. Create project via callTool ────────────────────────────
+  console.log("\n📦 Creating project via callTool...");
   const projectName = `E2E Test ${new Date().toISOString().slice(0, 16)}`;
-  const project = await stitch.createProject(projectName);
-  assert(typeof project.id === "string" && project.id.length > 0, `Created project: ${project.id}`);
-  assert(typeof project.projectId === "string" && project.projectId.length > 0, `Project has bare ID: ${project.projectId}`);
-  assert(!project.projectId.includes("projects/"), "projectId has no prefix");
+  const createResult = await stitch.callTool("create_project", { title: projectName });
+  const createdId = (createResult as any).name?.replace("projects/", "") ?? (createResult as any).projectId;
+  assert(typeof createdId === "string" && createdId.length > 0, `Created project: ${createdId}`);
 
-  // ── 3. Retrieve project by ID (handle pattern) ─────────────
-  console.log("\n🔍 Retrieving project by ID...");
-  const retrieved = stitch.project(project.id);
-  assert(retrieved.id === project.id, `Retrieved project matches: ${retrieved.id}`);
-  assert(retrieved.projectId === project.projectId, "Retrieved project has correct bare ID");
+  // ── 3. Retrieve project by identity map ─────────────────────
+  console.log("\n🔍 Retrieving project by identity map...");
+  const project = stitch.project(createdId);
+  assert(project.id === createdId, `Identity map handle matches: ${project.id}`);
 
   // Prove the handle works by listing screens (should be 0 on new project)
-  const emptyScreens = await retrieved.screens();
+  const emptyScreens = await project.screens();
   assert(Array.isArray(emptyScreens) && emptyScreens.length === 0, "New project has 0 screens");
 
   // ── 4. Generate screen ──────────────────────────────────────


### PR DESCRIPTION
`create_project` remains available as MCP tool via `stitchTools()` and `callTool()`. The domain API uses `project(id)` exclusively (identity map pattern).