### PR TITLE
fix: use printf instead of echo for base64 decode in fleet workflows

### DIFF
--- a/.github/workflows/fleet-analyze.yml
+++ b/.github/workflows/fleet-analyze.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Decode private key
         id: decode-key
         run: |
-          echo "${{ secrets.FLEET_APP_PRIVATE_KEY }}" | base64 -d > /tmp/fleet-app-key.pem
+          printf '%s' "${{ secrets.FLEET_APP_PRIVATE_KEY }}" | base64 -d > /tmp/fleet-app-key.pem
           {
             echo "pem<<PEMEOF"
             cat /tmp/fleet-app-key.pem

--- a/.github/workflows/fleet-dispatch.yml
+++ b/.github/workflows/fleet-dispatch.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Decode private key
         id: decode-key
         run: |
-          echo "${{ secrets.FLEET_APP_PRIVATE_KEY }}" | base64 -d > /tmp/fleet-app-key.pem
+          printf '%s' "${{ secrets.FLEET_APP_PRIVATE_KEY }}" | base64 -d > /tmp/fleet-app-key.pem
           {
             echo "pem<<PEMEOF"
             cat /tmp/fleet-app-key.pem

--- a/.github/workflows/fleet-merge.yml
+++ b/.github/workflows/fleet-merge.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Decode private key
         id: decode-key
         run: |
-          echo "${{ secrets.FLEET_APP_PRIVATE_KEY }}" | base64 -d > /tmp/fleet-app-key.pem
+          printf '%s' "${{ secrets.FLEET_APP_PRIVATE_KEY }}" | base64 -d > /tmp/fleet-app-key.pem
           {
             echo "pem<<PEMEOF"
             cat /tmp/fleet-app-key.pem


### PR DESCRIPTION
echo adds a trailing newline that corrupts the base64 stream when decoding the GitHub App private key. printf '%s' does not.