### PR TITLE
chore: publish readiness for @google/stitch-sdk@0.0.1

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -29,6 +29,8 @@
   },
   "files": [
     "dist",
+    "!dist/tsconfig.tsbuildinfo",
+    "!dist/package.json",
     "README.md"
   ],
   "publishConfig": {
@@ -44,11 +46,9 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.23.0",
-    "eventsource": "^2.0.2",
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@ai-sdk/google": "^3.0.43",
     "@swc/core": "^1.15.18",
     "@types/node": "^20.0.0",
     "ai": "^6.0.116",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -26,6 +26,7 @@ export { stitch } from "./singleton.js";
 
 // AI SDK adapter
 export { stitchTools } from "./tools-adapter.js";
+export type { StitchTool } from "./tools-adapter.js";
 
 // Error handling
 export { StitchError, StitchErrorCode } from "./spec/errors.js";

--- a/packages/sdk/src/tools-adapter.ts
+++ b/packages/sdk/src/tools-adapter.ts
@@ -12,9 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { dynamicTool, jsonSchema } from "ai";
 import { toolDefinitions } from "../generated/src/tool-definitions.js";
 import { getOrCreateClient } from "./singleton.js";
+
+/**
+ * Well-known symbol used by the Vercel AI SDK to identify schema objects.
+ * Using Symbol.for() ensures we match the exact same symbol the SDK uses
+ * internally, without importing it.
+ */
+const schemaSymbol = Symbol.for("vercel.ai.schema");
+
+/**
+ * A Stitch tool definition compatible with the Vercel AI SDK's Tool interface.
+ *
+ * This type is structurally equivalent to `Tool<unknown, unknown> & { type: 'dynamic' }`
+ * from the `ai` package. We define it locally to avoid a hard runtime dependency.
+ * Conformance is verified by tests that pass these objects into `generateText()`.
+ */
+export interface StitchTool {
+  type: 'dynamic';
+  description: string;
+  inputSchema: {
+    [key: symbol]: true;
+    _type: unknown;
+    readonly jsonSchema: unknown;
+    readonly validate?: undefined;
+  };
+  execute: (args: unknown) => Promise<unknown>;
+}
 
 /**
  * Returns Stitch tools in Vercel AI SDK format.
@@ -40,7 +65,7 @@ import { getOrCreateClient } from "./singleton.js";
 export function stitchTools(options?: {
   apiKey?: string;
   include?: string[];
-}): Record<string, ReturnType<typeof dynamicTool>> {
+}): Record<string, StitchTool> {
   const client = getOrCreateClient(options);
 
   const filtered = options?.include
@@ -50,11 +75,18 @@ export function stitchTools(options?: {
   return Object.fromEntries(
     filtered.map(t => [
       t.name,
-      dynamicTool({
+      {
+        type: 'dynamic' as const,
         description: t.description,
-        inputSchema: jsonSchema(t.inputSchema),
-        execute: async (args) => client.callTool(t.name, args as Record<string, any>),
-      }),
+        inputSchema: {
+          [schemaSymbol]: true as const,
+          _type: undefined as unknown,
+          validate: undefined,
+          get jsonSchema() { return t.inputSchema; },
+        },
+        execute: async (args: unknown) =>
+          client.callTool(t.name, args as Record<string, any>),
+      } satisfies StitchTool,
     ])
   );
 }

--- a/packages/sdk/test/unit/ai-sdk-compat.test.ts
+++ b/packages/sdk/test/unit/ai-sdk-compat.test.ts
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { generateText, stepCountIs } from "ai";
+import { generateText, stepCountIs, type Tool } from "ai";
 import { mockResponse, createTextMock, createToolCallMock } from "../helpers/model-helpers.js";
+import type { StitchTool } from "../../src/tools-adapter.js";
 
 const mockCallTool = vi.fn();
 
@@ -24,6 +25,22 @@ vi.mock("../../src/singleton.js", () => ({
     callTool: mockCallTool,
   }),
 }));
+
+/**
+ * Bridge StitchTool → AI SDK Tool for test assertions.
+ *
+ * Our StitchTool uses Symbol.for("vercel.ai.schema") which is runtime-identical
+ * to the AI SDK's internal schemaSymbol, but TypeScript can't verify unique symbol
+ * equality across module boundaries. This targeted assertion narrows to Record<string, Tool>
+ * rather than escaping to `any`.
+ */
+function asToolSet(tools: Record<string, StitchTool>): Record<string, Tool> {
+  // StitchTool uses Symbol.for("vercel.ai.schema") which is the same runtime value
+  // as the AI SDK's internal unique symbol, but TypeScript can't unify unique symbols
+  // across module boundaries. The `unknown` intermediate is the TS-recommended pattern
+  // for this class of cross-boundary type bridge.
+  return tools as unknown as Record<string, Tool>;
+}
 
 /**
  * TDD Cycle 3: AI SDK Compatibility
@@ -38,7 +55,7 @@ describe("AI SDK compatibility", () => {
 
   it("stitchTools() output is accepted by generateText({ tools })", async () => {
     const { stitchTools } = await import("../../src/tools-adapter.js");
-    const tools = stitchTools({ include: ["create_project"] });
+    const tools = asToolSet(stitchTools({ include: ["create_project"] }));
 
     const result = await generateText({
       model: createTextMock("I created a project."),
@@ -49,9 +66,24 @@ describe("AI SDK compatibility", () => {
     expect(result.text).toBe("I created a project.");
   });
 
-  it("mock LLM tool call triggers the correct execute function", async () => {
+  it("each tool satisfies the AI SDK Tool shape", async () => {
     const { stitchTools } = await import("../../src/tools-adapter.js");
     const tools = stitchTools({ include: ["create_project"] });
+
+    // Verify each tool has the structural properties the AI SDK expects.
+    // The generateText() tests are the authoritative conformance tests,
+    // but this validates individual field shapes explicitly.
+    for (const [, tool] of Object.entries(tools)) {
+      expect(tool.type).toBe('dynamic');
+      expect(typeof tool.description).toBe('string');
+      expect(tool.inputSchema).toHaveProperty('jsonSchema');
+      expect(typeof tool.execute).toBe('function');
+    }
+  });
+
+  it("mock LLM tool call triggers the correct execute function", async () => {
+    const { stitchTools } = await import("../../src/tools-adapter.js");
+    const tools = asToolSet(stitchTools({ include: ["create_project"] }));
 
     mockCallTool.mockResolvedValue({ name: "projects/123", title: "Test Project" });
 
@@ -71,7 +103,7 @@ describe("AI SDK compatibility", () => {
 
   it("tool result flows back through the AI SDK pipeline", async () => {
     const { stitchTools } = await import("../../src/tools-adapter.js");
-    const tools = stitchTools({ include: ["create_project"] });
+    const tools = asToolSet(stitchTools({ include: ["create_project"] }));
 
     mockCallTool.mockResolvedValue({ name: "projects/456", title: "My App" });
 
@@ -90,3 +122,4 @@ describe("AI SDK compatibility", () => {
     expect(result.text).toBe("Created project My App with ID 456.");
   });
 });
+


### PR DESCRIPTION
## Summary

Prepares `@google/stitch-sdk` for its initial npm publish (v0.0.1).

### Changes

- **Decouple `ai` runtime dependency** — Replace `dynamicTool()`/`jsonSchema()` imports with plain objects using `Symbol.for('vercel.ai.schema')`. Zero runtime dependency on `ai` while maintaining full structural compatibility with the Vercel AI SDK.
- **Export `StitchTool` type** — New public type for consumers who want to type-check tool definitions.
- **Remove unused dependencies** — `eventsource` (prod) and `@ai-sdk/google` (dev).
- **Clean tarball** — Exclude `dist/package.json` (stale tsc copy) and `dist/tsconfig.tsbuildinfo` (81KB build cache) via `files` exclusions.
- **Add conformance tests** — Typed `asToolSet()` bridge function and structural property assertions to catch AI SDK type drift.

### Verification

- ✅ 56 tests pass (including 4 AI SDK compatibility tests)
- ✅ Build compiles cleanly
- ✅ Tarball: **74 files / 114KB** (was 156 files / 248KB)
- ✅ No `ai` runtime import in compiled output