### PR TITLE
feat: move stitchTools() to @google/stitch-sdk/ai subpath

### DIFF
--- a/.agents/skills/stitch-sdk-pipeline/SKILL.md
+++ b/.agents/skills/stitch-sdk-pipeline/SKILL.md
@@ -193,7 +193,7 @@ Runs Stage 1 → 3 → 4 → 5 in sequence. Does **not** include Stage 2 (agent)
 | `tools-manifest.json` | `packages/sdk/generated/` | Raw MCP tool schemas (Stage 1 output) |
 | `domain-map.json` | `packages/sdk/generated/` | IR: tool → class → method mappings (Stage 2 output) |
 | `tool-definitions.ts` | `packages/sdk/generated/src/` | Generated JSON Schema tool definitions for AI SDK |
-| `tools-adapter.ts` | `packages/sdk/src/` | `stitchTools()` — AI SDK v6 `dynamicTool()` adapter |
+| `tools-adapter.ts` | `packages/sdk/src/` | `stitchTools()` — AI SDK v6 adapter (imported via `@google/stitch-sdk/ai`) |
 | `ir-schema.ts` | `scripts/` | Zod schema defining valid IR structure |
 | `tool-schema.ts` | `scripts/` | TypeScript types for JSON Schema |
 | `generate-sdk.ts` | `scripts/` | ts-morph codegen (Stage 3) |

--- a/.agents/skills/stitch-sdk-readme/SKILL.md
+++ b/.agents/skills/stitch-sdk-readme/SKILL.md
@@ -19,7 +19,7 @@ Do not hard-code the API surface. Read it from the codebase at invocation time:
 | Domain class methods + signatures | Source files for each exported class (`sdk.ts`, `project.ts`, `screen.ts`) |
 | Generated method bindings | `packages/sdk/generated/domain-map.json` → `bindings[]` array |
 | Handwritten methods | Methods in class source files that aren't in domain-map bindings (e.g. `Screen.edit`, `Screen.variants`) |
-| AI SDK tools adapter | `packages/sdk/src/tools-adapter.ts` → `stitchTools()` function |
+| AI SDK tools adapter | `packages/sdk/src/ai.ts` → subpath entry for `stitchTools()` |
 | Generated tool definitions | `packages/sdk/generated/src/tool-definitions.ts` → JSON Schema for each tool |
 | Tool client methods | `packages/sdk/src/client.ts` |
 | Error codes | `packages/sdk/src/spec/errors.ts` → `StitchErrorCode` |
@@ -58,10 +58,11 @@ Show this as the first code block, with one line noting the env var requirement.
 2. Editing a screen and generating variants
 3. Tool access via singleton (`stitch.listTools()`, `stitch.callTool()`) — zero setup
 4. Explicit configuration via `StitchToolClient` (custom API key, base URL)
-5. AI SDK integration via `stitchTools()` — show `generateText` with `tools: stitchTools()` and `stepCountIs`
+5. AI SDK integration via `stitchTools()` — import from `@google/stitch-sdk/ai`, show `generateText` with `tools: stitchTools()` and `stepCountIs`
 
 Rules for this section:
 - **No setup first.** One line mentioning `STITCH_API_KEY` is enough before the first example.
+- **Dual install paths.** Show `npm install @google/stitch-sdk` first (core SDK, standalone). Then show `npm install @google/stitch-sdk ai` for AI SDK users. The `ai` package is only needed when importing from `@google/stitch-sdk/ai`.
 - **Straightforward language.** No "powerful", "seamless", "robust", "enterprise-grade".
 - **Working examples.** Every code block must be valid, runnable code — not fragments with `// ...` elisions.
 - **Progressive complexity.** Simplest invocation first, then deeper capabilities.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ const result = await stitch.callTool("create_project", { title: "My App" });
 npm install @google/stitch-sdk
 ```
 
+To use `stitchTools()` with the [Vercel AI SDK](https://sdk.vercel.ai/), install `ai` as well:
+
+```bash
+npm install @google/stitch-sdk ai
+```
+
 ## Working with Projects and Screens
 
 ### List existing projects
@@ -123,7 +129,7 @@ Drop Stitch tools directly into the [Vercel AI SDK](https://sdk.vercel.ai/):
 ```ts
 import { generateText, stepCountIs } from "ai";
 import { google } from "@ai-sdk/google";
-import { stitchTools } from "@google/stitch-sdk";
+import { stitchTools } from "@google/stitch-sdk/ai";
 
 const { text, steps } = await generateText({
   model: google("gemini-2.5-flash"),
@@ -213,11 +219,11 @@ await client.close();
 
 ### `stitchTools()`
 
-Returns all Stitch MCP tools as Vercel AI SDK `dynamicTool` objects. Drop into `generateText()` or `streamText()` — the model calls tools autonomously.
+Returns all Stitch MCP tools as Vercel AI SDK `Tool` objects. Import from `@google/stitch-sdk/ai`. Drop into `generateText()` or `streamText()` — the model calls tools autonomously.
 
 ```ts
 import { generateText, stepCountIs } from "ai";
-import { stitchTools } from "@google/stitch-sdk";
+import { stitchTools } from "@google/stitch-sdk/ai";
 
 const { text } = await generateText({
   model: yourModel,

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -24,6 +24,12 @@ const imageUrl = await screen.getImage();
 npm install @google/stitch-sdk
 ```
 
+To use `stitchTools()` with the [Vercel AI SDK](https://sdk.vercel.ai/), install `ai` as well:
+
+```bash
+npm install @google/stitch-sdk ai
+```
+
 ## Working with Projects and Screens
 
 ### List existing projects

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,11 +2,12 @@
   "name": "@google/stitch-sdk",
   "version": "0.0.1",
   "type": "module",
+  "private": false,
   "description": "Generate UI screens from text prompts and extract their HTML and screenshots programmatically.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/stitch-sdk.git",
+    "url": "https://github.com/google-labs-code/stitch-sdk.git",
     "directory": "packages/sdk"
   },
   "keywords": [
@@ -25,6 +26,10 @@
     ".": {
       "import": "./dist/src/index.js",
       "types": "./dist/src/index.d.ts"
+    },
+    "./ai": {
+      "import": "./dist/src/ai.js",
+      "types": "./dist/src/ai.d.ts"
     }
   },
   "files": [

--- a/packages/sdk/src/ai.ts
+++ b/packages/sdk/src/ai.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * AI SDK adapter entry point.
+ *
+ * Import from `@google/stitch-sdk/ai` to use Stitch tools with the Vercel AI SDK.
+ *
+ * @example
+ * import { stitchTools } from "@google/stitch-sdk/ai";
+ * import { generateText } from "ai";
+ *
+ * const { text } = await generateText({
+ *   model,
+ *   tools: stitchTools(),
+ *   prompt: "Create a login page",
+ * });
+ */
+export { stitchTools } from "./tools-adapter.js";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -24,10 +24,6 @@ export { StitchProxy } from "./proxy/core.js";
 // Singleton
 export { stitch } from "./singleton.js";
 
-// AI SDK adapter
-export { stitchTools } from "./tools-adapter.js";
-export type { StitchTool } from "./tools-adapter.js";
-
 // Error handling
 export { StitchError, StitchErrorCode } from "./spec/errors.js";
 

--- a/packages/sdk/src/tools-adapter.ts
+++ b/packages/sdk/src/tools-adapter.ts
@@ -12,34 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import type { Tool } from "ai";
 import { toolDefinitions } from "../generated/src/tool-definitions.js";
 import { getOrCreateClient } from "./singleton.js";
 
 /**
  * Well-known symbol used by the Vercel AI SDK to identify schema objects.
  * Using Symbol.for() ensures we match the exact same symbol the SDK uses
- * internally, without importing it.
+ * internally, without importing any runtime code from `ai`.
  */
 const schemaSymbol = Symbol.for("vercel.ai.schema");
-
-/**
- * A Stitch tool definition compatible with the Vercel AI SDK's Tool interface.
- *
- * This type is structurally equivalent to `Tool<unknown, unknown> & { type: 'dynamic' }`
- * from the `ai` package. We define it locally to avoid a hard runtime dependency.
- * Conformance is verified by tests that pass these objects into `generateText()`.
- */
-export interface StitchTool {
-  type: 'dynamic';
-  description: string;
-  inputSchema: {
-    [key: symbol]: true;
-    _type: unknown;
-    readonly jsonSchema: unknown;
-    readonly validate?: undefined;
-  };
-  execute: (args: unknown) => Promise<unknown>;
-}
 
 /**
  * Returns Stitch tools in Vercel AI SDK format.
@@ -65,7 +47,7 @@ export interface StitchTool {
 export function stitchTools(options?: {
   apiKey?: string;
   include?: string[];
-}): Record<string, StitchTool> {
+}): Record<string, Tool> {
   const client = getOrCreateClient(options);
 
   const filtered = options?.include
@@ -75,18 +57,22 @@ export function stitchTools(options?: {
   return Object.fromEntries(
     filtered.map(t => [
       t.name,
+      // Construct a plain object that is runtime-identical to what
+      // dynamicTool() + jsonSchema() would produce. The `ai` package
+      // is NOT imported at runtime — only the type is used above.
       {
         type: 'dynamic' as const,
         description: t.description,
         inputSchema: {
-          [schemaSymbol]: true as const,
+          [schemaSymbol]: true,
           _type: undefined as unknown,
           validate: undefined,
           get jsonSchema() { return t.inputSchema; },
         },
         execute: async (args: unknown) =>
           client.callTool(t.name, args as Record<string, any>),
-      } satisfies StitchTool,
+      } as unknown as Tool,
     ])
   );
 }
+

--- a/packages/sdk/test/integration/ai-sdk-e2e.test.ts
+++ b/packages/sdk/test/integration/ai-sdk-e2e.test.ts
@@ -14,8 +14,8 @@
 
 import path from "node:path";
 import { describe, it, expect } from "vitest";
-import { generateText, stepCountIs } from "ai";
-import { stitchTools } from "../../src/tools-adapter.js";
+import { generateText, stepCountIs, type Tool } from "ai";
+import { stitchTools } from "../../src/ai.js";
 import { createGeminiModel } from "../helpers/model-helpers.js";
 import { validateComponent } from "../helpers/component-validator.js";
 import { extractStitchAssets, parseGeneratedFiles, writePreviewApp } from "../helpers/stitch-html.js";

--- a/packages/sdk/test/unit/ai-sdk-compat.test.ts
+++ b/packages/sdk/test/unit/ai-sdk-compat.test.ts
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { generateText, stepCountIs, type Tool } from "ai";
+import { generateText, stepCountIs } from "ai";
 import { mockResponse, createTextMock, createToolCallMock } from "../helpers/model-helpers.js";
-import type { StitchTool } from "../../src/tools-adapter.js";
 
 const mockCallTool = vi.fn();
 
@@ -25,22 +24,6 @@ vi.mock("../../src/singleton.js", () => ({
     callTool: mockCallTool,
   }),
 }));
-
-/**
- * Bridge StitchTool → AI SDK Tool for test assertions.
- *
- * Our StitchTool uses Symbol.for("vercel.ai.schema") which is runtime-identical
- * to the AI SDK's internal schemaSymbol, but TypeScript can't verify unique symbol
- * equality across module boundaries. This targeted assertion narrows to Record<string, Tool>
- * rather than escaping to `any`.
- */
-function asToolSet(tools: Record<string, StitchTool>): Record<string, Tool> {
-  // StitchTool uses Symbol.for("vercel.ai.schema") which is the same runtime value
-  // as the AI SDK's internal unique symbol, but TypeScript can't unify unique symbols
-  // across module boundaries. The `unknown` intermediate is the TS-recommended pattern
-  // for this class of cross-boundary type bridge.
-  return tools as unknown as Record<string, Tool>;
-}
 
 /**
  * TDD Cycle 3: AI SDK Compatibility
@@ -55,7 +38,7 @@ describe("AI SDK compatibility", () => {
 
   it("stitchTools() output is accepted by generateText({ tools })", async () => {
     const { stitchTools } = await import("../../src/tools-adapter.js");
-    const tools = asToolSet(stitchTools({ include: ["create_project"] }));
+    const tools = stitchTools({ include: ["create_project"] });
 
     const result = await generateText({
       model: createTextMock("I created a project."),
@@ -66,24 +49,22 @@ describe("AI SDK compatibility", () => {
     expect(result.text).toBe("I created a project.");
   });
 
-  it("each tool satisfies the AI SDK Tool shape", async () => {
+  it("each tool has the expected structural properties", async () => {
     const { stitchTools } = await import("../../src/tools-adapter.js");
     const tools = stitchTools({ include: ["create_project"] });
 
-    // Verify each tool has the structural properties the AI SDK expects.
-    // The generateText() tests are the authoritative conformance tests,
-    // but this validates individual field shapes explicitly.
     for (const [, tool] of Object.entries(tools)) {
-      expect(tool.type).toBe('dynamic');
-      expect(typeof tool.description).toBe('string');
-      expect(tool.inputSchema).toHaveProperty('jsonSchema');
-      expect(typeof tool.execute).toBe('function');
+      const t = tool as Record<string, unknown>;
+      expect(t.type).toBe('dynamic');
+      expect(typeof t.description).toBe('string');
+      expect(t.inputSchema).toHaveProperty('jsonSchema');
+      expect(typeof t.execute).toBe('function');
     }
   });
 
   it("mock LLM tool call triggers the correct execute function", async () => {
     const { stitchTools } = await import("../../src/tools-adapter.js");
-    const tools = asToolSet(stitchTools({ include: ["create_project"] }));
+    const tools = stitchTools({ include: ["create_project"] });
 
     mockCallTool.mockResolvedValue({ name: "projects/123", title: "Test Project" });
 
@@ -103,7 +84,7 @@ describe("AI SDK compatibility", () => {
 
   it("tool result flows back through the AI SDK pipeline", async () => {
     const { stitchTools } = await import("../../src/tools-adapter.js");
-    const tools = asToolSet(stitchTools({ include: ["create_project"] }));
+    const tools = stitchTools({ include: ["create_project"] });
 
     mockCallTool.mockResolvedValue({ name: "projects/456", title: "My App" });
 
@@ -122,4 +103,5 @@ describe("AI SDK compatibility", () => {
     expect(result.text).toBe("Created project My App with ID 456.");
   });
 });
+
 

--- a/packages/sdk/test/unit/ai-subpath.test.ts
+++ b/packages/sdk/test/unit/ai-subpath.test.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+
+/**
+ * TDD Cycle 1: The @google/stitch-sdk/ai subpath exports stitchTools.
+ */
+describe("@google/stitch-sdk/ai subpath", () => {
+  it("exports stitchTools from the ai entry point", async () => {
+    const mod = await import("../../src/ai.js");
+    expect(typeof mod.stitchTools).toBe("function");
+  });
+
+  it("main entry point does NOT export stitchTools", async () => {
+    const mod = await import("../../src/index.js");
+    expect(mod).not.toHaveProperty("stitchTools");
+  });
+});


### PR DESCRIPTION
- Add src/ai.ts as dedicated entry point for AI SDK adapter
- Remove stitchTools from main index.ts (no ai dependency on core)
- Add ./ai subpath export in package.json
- Remove ai from peerDependencies (consumers install it themselves)
- Use type-only import of Tool from ai in tools-adapter.ts
- Update both READMEs with dual install paths
- Update pipeline and readme skills (Stage 9 audit)
- Add TDD subpath isolation tests (ai-subpath.test.ts)