### PR TITLE
feat: Expose modelId and getProject in Domain Layer

### DIFF
--- a/packages/sdk/generated/domain-map.json
+++ b/packages/sdk/generated/domain-map.json
@@ -77,6 +77,10 @@
           "from": "param",
           "optional": true,
           "default": "DESKTOP"
+        },
+        "modelId": {
+          "from": "param",
+          "optional": true
         }
       },
       "returns": {
@@ -199,6 +203,24 @@
           }
         ],
         "array": true
+      }
+    },
+    {
+      "tool": "get_project",
+      "class": "Stitch",
+      "method": "getProject",
+      "args": {
+        "projectId": {
+          "from": "param"
+        },
+        "name": {
+          "from": "computed",
+          "template": "projects/{projectId}"
+        }
+      },
+      "returns": {
+        "class": "Project",
+        "projection": []
       }
     },
     {

--- a/packages/sdk/generated/src/index.ts
+++ b/packages/sdk/generated/src/index.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:efa6858b5d46...)
-Generated: 2026-03-08T00:44:24.555Z
+        domain-map.json     (sha256:49ed76857ca3...)
+Generated: 2026-03-12T15:11:01.420Z
  */
 export { Stitch } from "./stitch.js";
 export { Project } from "./project.js";

--- a/packages/sdk/generated/src/project.ts
+++ b/packages/sdk/generated/src/project.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:efa6858b5d46...)
-Generated: 2026-03-08T00:44:24.555Z
+        domain-map.json     (sha256:49ed76857ca3...)
+Generated: 2026-03-12T15:11:01.420Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";
@@ -34,9 +34,9 @@ export class Project {
      * Generates a new screen within a project from a text prompt.
      * Tool: generate_screen_from_text
      */
-    async generate(prompt: string, deviceType?: "DEVICE_TYPE_UNSPECIFIED" | "MOBILE" | "DESKTOP" | "TABLET" | "AGNOSTIC"): Promise<Screen> {
+    async generate(prompt: string, deviceType?: "DEVICE_TYPE_UNSPECIFIED" | "MOBILE" | "DESKTOP" | "TABLET" | "AGNOSTIC", modelId?: "MODEL_ID_UNSPECIFIED" | "GEMINI_3_PRO" | "GEMINI_3_FLASH"): Promise<Screen> {
         try {
-          const raw = await this.client.callTool<any>("generate_screen_from_text", { projectId: this.projectId, prompt, deviceType });
+          const raw = await this.client.callTool<any>("generate_screen_from_text", { projectId: this.projectId, prompt, deviceType, modelId });
           return new Screen(this.client, { ...raw.outputComponents[0].design.screens[0], projectId: this.projectId });
         } catch (error) {
           throw StitchError.fromUnknown(error);

--- a/packages/sdk/generated/src/screen.ts
+++ b/packages/sdk/generated/src/screen.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:efa6858b5d46...)
-Generated: 2026-03-08T00:44:24.555Z
+        domain-map.json     (sha256:49ed76857ca3...)
+Generated: 2026-03-12T15:11:01.420Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/stitch.ts
+++ b/packages/sdk/generated/src/stitch.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:efa6858b5d46...)
-Generated: 2026-03-08T00:44:24.555Z
+        domain-map.json     (sha256:49ed76857ca3...)
+Generated: 2026-03-12T15:11:01.420Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";
@@ -23,6 +23,19 @@ export class Stitch {
         try {
           const raw = await this.client.callTool<any>("list_projects", {  });
           return (raw.projects || []).map((item: any) => new Project(this.client, item));
+        } catch (error) {
+          throw StitchError.fromUnknown(error);
+        }
+    }
+
+    /**
+     * Retrieves the details of a specific Stitch project using its project name.
+     * Tool: get_project
+     */
+    async getProject(projectId: any): Promise<Project> {
+        try {
+          const raw = await this.client.callTool<any>("get_project", { projectId, name: `projects/${projectId}` });
+          return new Project(this.client, raw);
         } catch (error) {
           throw StitchError.fromUnknown(error);
         }

--- a/packages/sdk/generated/src/tool-definitions.ts
+++ b/packages/sdk/generated/src/tool-definitions.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:efa6858b5d46...)
-Generated: 2026-03-08T00:44:24.555Z
+        domain-map.json     (sha256:49ed76857ca3...)
+Generated: 2026-03-12T15:11:01.420Z
  */
 /** Static tool definition from the Stitch MCP server manifest. */
 export interface ToolDefinition {

--- a/packages/sdk/generated/stitch-sdk.lock
+++ b/packages/sdk/generated/stitch-sdk.lock
@@ -7,17 +7,17 @@
     "serverUrl": "https://stitch.googleapis.com/mcp"
   },
   "generated": {
-    "generatedAt": "2026-03-08T00:44:24.632Z",
-    "sourceHash": "sha256:e1a11b9665e74c38dbb455b8b85a4e4604142cf7baa2005719e55ccc11920000",
+    "generatedAt": "2026-03-12T15:11:01.970Z",
+    "sourceHash": "sha256:cea9331adba84d7c6a1e79a28399558ce286f952dff83bd7cd280aa2d57c6cff",
     "manifestHash": "sha256:1f84b31604f95580325952f0c150a3e045543fad2596e9a4d8ed15c07e0cbf9b",
-    "domainMapHash": "sha256:efa6858b5d46f8509d810a816b9cab87f1b3e33b3c8be84d973346181dd6d134",
+    "domainMapHash": "sha256:49ed76857ca38b8df687014e82377a40f0509ebc3158574bec35d13290dbf29b",
     "fileCount": 5
   },
   "domainMap": {
-    "generatedAt": "2026-03-08T00:44:24.632Z",
-    "sourceHash": "sha256:efa6858b5d46f8509d810a816b9cab87f1b3e33b3c8be84d973346181dd6d134",
+    "generatedAt": "2026-03-12T15:11:01.970Z",
+    "sourceHash": "sha256:49ed76857ca38b8df687014e82377a40f0509ebc3158574bec35d13290dbf29b",
     "manifestHash": "sha256:1f84b31604f95580325952f0c150a3e045543fad2596e9a4d8ed15c07e0cbf9b",
     "classCount": 3,
-    "bindingCount": 8
+    "bindingCount": 9
   }
 }

--- a/packages/sdk/test/unit/sdk.test.ts
+++ b/packages/sdk/test/unit/sdk.test.ts
@@ -148,9 +148,21 @@ describe("SDK Unit Tests", () => {
   });
 
   describe("Stitch Class (Identity Map)", () => {
-    it("should not have a getProject method — use project(id) instead", () => {
+    it("getProject should call get_project tool and return a Project instance", async () => {
       const sdk = new Stitch(mockClient);
-      expect(typeof (sdk as any).getProject).toBe("undefined");
+
+      (mockClient.callTool as Mock).mockResolvedValue({
+        name: "projects/proj-123"
+      });
+
+      const result = await sdk.getProject("proj-123");
+
+      expect(mockClient.callTool).toHaveBeenCalledWith("get_project", {
+        projectId: "proj-123",
+        name: "projects/proj-123"
+      });
+      expect(result).toBeInstanceOf(Project);
+      expect(result.id).toBe("proj-123");
     });
 
     it("should not have a createProject method — use callTool or stitchTools() instead", () => {
@@ -190,7 +202,8 @@ describe("SDK Unit Tests", () => {
       expect(mockClient.callTool).toHaveBeenCalledWith("generate_screen_from_text", {
         projectId: projectId,
         prompt: prompt,
-        deviceType: undefined
+        deviceType: undefined,
+        modelId: undefined
       });
 
       expect(result).toBeInstanceOf(Screen);


### PR DESCRIPTION
Fixes #37, #48

*   Adds `modelId` argument mapping to `generate_screen_from_text` tool binding.
*   Adds new binding mapping the `get_project` tool to a `getProject` method on the `Stitch` domain class.
*   Regenerates source files to reflect binding updates.
*   Updates unit tests in `sdk.test.ts` to assert that `Stitch.getProject` invokes the underlying tool correctly, replacing the old test that asserted the method's absence.
*   Ensures `modelId` reflects in the expected argument lists in relevant generation tests.

---
*PR created automatically by Jules for task [3240784478917157150](https://jules.google.com/task/3240784478917157150) started by @davideast*