### PR TITLE
feat: add core code snippets

### DIFF
--- a/packages/sdk/examples/_require-key.ts
+++ b/packages/sdk/examples/_require-key.ts
@@ -1,0 +1,5 @@
+if (!process.env.STITCH_API_KEY) {
+  console.log("⏭️  Set STITCH_API_KEY to run this snippet.");
+  console.log("   STITCH_API_KEY=your-key bun", process.argv[1]);
+  process.exit(0);
+}

--- a/packages/sdk/examples/browse-designs.ts
+++ b/packages/sdk/examples/browse-designs.ts
@@ -1,0 +1,45 @@
+/**
+ * List all projects the user has, then for each project list its screens
+ * and log their HTML and Image URLs.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/browse-designs.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+console.log("🔍 Fetching projects...");
+
+const projects = await stitch.projects();
+
+if (projects.length === 0) {
+  console.log("📭 No projects found.");
+  process.exit(0);
+}
+
+console.log(`✅ Found ${projects.length} project(s).\n`);
+
+for (const project of projects) {
+  console.log(`📁 Project: ${project.id}`);
+
+  const screens = await project.screens();
+  if (screens.length === 0) {
+    console.log("  📭 No screens in this project.");
+    continue;
+  }
+
+  for (const screen of screens) {
+    console.log(`  📱 Screen: ${screen.id}`);
+
+    try {
+      const htmlUrl = await screen.getHtml();
+      const imageUrl = await screen.getImage();
+      console.log(`     📄 HTML:  ${htmlUrl || "(No HTML available)"}`);
+      console.log(`     🖼️  Image: ${imageUrl || "(No Image available)"}`);
+    } catch (e: any) {
+      console.log(`     ❌ Error fetching URLs: ${e.message}`);
+    }
+  }
+
+  console.log(); // blank line
+}

--- a/packages/sdk/examples/browse-projects.ts
+++ b/packages/sdk/examples/browse-projects.ts
@@ -1,0 +1,32 @@
+/**
+ * List all projects using stitch.projects() and log their IDs and screen counts.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/browse-projects.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+console.log("🔍 Fetching your Stitch projects...\n");
+
+try {
+  const projects = await stitch.projects();
+
+  if (projects.length === 0) {
+    console.log("📭 No projects found.");
+    process.exit(0);
+  }
+
+  console.log(`✅ Found ${projects.length} project(s):`);
+
+  for (const project of projects) {
+    const screens = await project.screens();
+
+    console.log(`\n📁 Project: ${project.id}`);
+    console.log(`   📱 Screens: ${screens.length}`);
+  }
+
+} catch (e: any) {
+  console.error("\n❌ Failed to fetch projects:");
+  console.error(e.message);
+}

--- a/packages/sdk/examples/edit-screen.ts
+++ b/packages/sdk/examples/edit-screen.ts
@@ -1,0 +1,56 @@
+/**
+ * Pick an existing screen and call screen.edit(),
+ * then log the updated screen.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/edit-screen.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+console.log("🔍 Fetching your projects to find a screen to edit...");
+
+const projects = await stitch.projects();
+if (projects.length === 0) {
+  console.log("📭 No projects found. Run getting-started.ts first.");
+  process.exit(0);
+}
+
+// Find the first screen available across all projects
+let targetScreen = null;
+let targetProject = null;
+
+for (const project of projects) {
+  const screens = await project.screens();
+  if (screens.length > 0) {
+    targetProject = project;
+    targetScreen = screens[0];
+    break;
+  }
+}
+
+if (!targetScreen || !targetProject) {
+  console.log("📭 No screens found in any project. Run getting-started.ts first.");
+  process.exit(0);
+}
+
+console.log(`✅ Found screen ${targetScreen.id} in project ${targetProject.id}`);
+
+const editPrompt = "Change the color scheme to dark mode";
+console.log(`\n🎨 Editing screen with prompt: "${editPrompt}"...`);
+console.log("   (This may take up to a minute)");
+
+try {
+  const editedScreen = await targetScreen.edit(editPrompt);
+  console.log(`✅ Screen successfully edited: ${editedScreen.id}`);
+
+  const originalHtml = await targetScreen.getHtml();
+  const newHtml = await editedScreen.getHtml();
+
+  console.log("\n✨ Output:");
+  console.log(`📄 Original HTML: ${originalHtml}`);
+  console.log(`📄 Edited HTML:   ${newHtml}`);
+} catch (e: any) {
+  console.error("❌ Failed to edit screen:");
+  console.error(e.message);
+}

--- a/packages/sdk/examples/generate-screen.ts
+++ b/packages/sdk/examples/generate-screen.ts
@@ -1,0 +1,28 @@
+/**
+ * Create a new project, call project.generate() to generate a screen,
+ * then log the resulting screen's HTML URL.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/generate-screen.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+console.log("🚀 Creating a project for screen generation...");
+
+const rawProject = await stitch.callTool<any>("create_project", { title: "Analytics App" });
+const project = stitch.project(rawProject.name);
+console.log(`✅ Project created: ${project.id}`);
+
+const prompt = "A dashboard for a SaaS analytics tool";
+console.log(`🎨 Generating screen with prompt: "${prompt}"...`);
+console.log("   (This may take up to a minute)");
+
+const screen = await project.generate(prompt);
+console.log(`✅ Screen generated: ${screen.id}`);
+
+console.log("🔍 Fetching HTML...");
+const htmlUrl = await screen.getHtml();
+
+console.log("\n✨ Output:");
+console.log(`📄 HTML URL: ${htmlUrl}`);

--- a/packages/sdk/examples/generate-variants.ts
+++ b/packages/sdk/examples/generate-variants.ts
@@ -1,0 +1,62 @@
+/**
+ * Pick an existing screen and call screen.variants() with variant options,
+ * then log the resulting variant screens.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/generate-variants.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+console.log("🔍 Fetching your projects to find a screen to generate variants from...");
+
+const projects = await stitch.projects();
+if (projects.length === 0) {
+  console.log("📭 No projects found. Run getting-started.ts first.");
+  process.exit(0);
+}
+
+// Find the first screen available
+let targetScreen = null;
+let targetProject = null;
+
+for (const project of projects) {
+  const screens = await project.screens();
+  if (screens.length > 0) {
+    targetProject = project;
+    targetScreen = screens[0];
+    break;
+  }
+}
+
+if (!targetScreen || !targetProject) {
+  console.log("📭 No screens found in any project. Run getting-started.ts first.");
+  process.exit(0);
+}
+
+console.log(`✅ Found base screen ${targetScreen.id} in project ${targetProject.id}`);
+
+const variantsPrompt = "Change the button style to outline";
+const variantOptions = { numVariants: 3 };
+
+console.log(`\n🎨 Generating variants with prompt: "${variantsPrompt}"...`);
+console.log("   (This may take up to a minute)");
+
+try {
+  // Note: The method is named `variants` in the SDK domain class (as mapped in domain-map.json).
+  // The issue refers to it conceptually as "generateVariants".
+  const variantScreens = await targetScreen.variants(variantsPrompt, variantOptions);
+
+  console.log(`✅ Successfully generated ${variantScreens.length} variants!`);
+
+  for (let i = 0; i < variantScreens.length; i++) {
+    const screen = variantScreens[i];
+    const htmlUrl = await screen.getHtml();
+    console.log(`\n✨ Variant ${i + 1} (${screen.id}):`);
+    console.log(`   📄 HTML URL: ${htmlUrl}`);
+  }
+
+} catch (e: any) {
+  console.error("❌ Failed to generate variants:");
+  console.error(e.message);
+}

--- a/packages/sdk/examples/getting-started.ts
+++ b/packages/sdk/examples/getting-started.ts
@@ -1,0 +1,29 @@
+/**
+ * The simplest possible example: connect to Stitch, create a project, generate a screen, and log the result.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/getting-started.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+console.log("🚀 Getting started with Stitch...");
+
+// 1. Create a project
+console.log("📁 Creating a new project...");
+const rawProject = await stitch.callTool<any>("create_project", { title: "Getting Started" });
+const project = stitch.project(rawProject.name);
+console.log(`✅ Project created: ${project.id}`);
+
+// 2. Generate a screen
+console.log("🎨 Generating a screen: 'A simple login page'...");
+const screen = await project.generate("A simple login page");
+console.log(`✅ Screen generated: ${screen.id}`);
+
+// 3. Get outputs
+const htmlUrl = await screen.getHtml();
+const imageUrl = await screen.getImage();
+
+console.log("\n✨ Results:");
+console.log(`📄 HTML URL:  ${htmlUrl}`);
+console.log(`🖼️  Image URL: ${imageUrl}`);


### PR DESCRIPTION
This PR adds 6 foundational code snippets to `packages/sdk/examples/` as standalone scripts demonstrating core capabilities of the Stitch SDK:
1. `getting-started.ts`: Connects to Stitch, creates a project, generates a screen and gets the HTML.
2. `browse-designs.ts`: Lists all user projects and their corresponding screens and outputs their URLs.
3. `generate-screen.ts`: Creates a new project and generates a screen from a text prompt.
4. `edit-screen.ts`: Finds an existing screen and modifies it using a prompt.
5. `generate-variants.ts`: Finds an existing screen and creates variants using `screen.variants(...)`.
6. `browse-projects.ts`: Lists all user projects and output their screen counts.

Each snippet incorporates environment gating via `_require-key.js` and imports the `stitch` singleton from `@google/stitch-sdk`.

Fixes #15, #16, #17, #18, #19, #21

---
*PR created automatically by Jules for task [1639889987727550874](https://jules.google.com/task/1639889987727550874) started by @davideast*