### PR TITLE
feat: add utility and advanced example snippets

### DIFF
--- a/packages/sdk/examples/_require-key.ts
+++ b/packages/sdk/examples/_require-key.ts
@@ -1,0 +1,5 @@
+if (!process.env.STITCH_API_KEY) {
+  console.log("⏭️  Set STITCH_API_KEY to run this snippet.");
+  console.log("   STITCH_API_KEY=your-key bun", process.argv[1]);
+  process.exit(0);
+}

--- a/packages/sdk/examples/custom-client.ts
+++ b/packages/sdk/examples/custom-client.ts
@@ -1,0 +1,39 @@
+/**
+ * Instantiate a custom StitchToolClient using OAuth credentials.
+ * This bypasses the default STITCH_API_KEY environment variable.
+ *
+ * Usage:
+ *   STITCH_ACCESS_TOKEN=your-token GOOGLE_CLOUD_PROJECT=your-project bun packages/sdk/examples/custom-client.ts
+ */
+import { StitchToolClient } from "@google/stitch-sdk";
+
+if (!process.env.STITCH_ACCESS_TOKEN || !process.env.GOOGLE_CLOUD_PROJECT) {
+  console.log("⏭️  Set STITCH_ACCESS_TOKEN and GOOGLE_CLOUD_PROJECT to run this snippet.");
+  console.log("   STITCH_ACCESS_TOKEN=... GOOGLE_CLOUD_PROJECT=... bun", process.argv[1]);
+  process.exit(0);
+}
+
+const client = new StitchToolClient({
+  accessToken: process.env.STITCH_ACCESS_TOKEN,
+  projectId: process.env.GOOGLE_CLOUD_PROJECT,
+});
+
+try {
+  console.log("Connecting with OAuth credentials...");
+  await client.connect();
+  console.log("Connected successfully!");
+
+  console.log("Fetching tools list...");
+  const tools = await client.listTools();
+  console.log(`Found ${tools.tools.length} available tools.`);
+
+  // List tools to show successful authentication
+  tools.tools.forEach((t) => {
+    console.log(`- ${t.name}`);
+  });
+} catch (error) {
+  console.error("Failed to connect or list tools:", error);
+} finally {
+  console.log("Closing client connection...");
+  await client.close();
+}

--- a/packages/sdk/examples/download-artifacts.ts
+++ b/packages/sdk/examples/download-artifacts.ts
@@ -1,0 +1,70 @@
+/**
+ * Download HTML and screenshot artifacts from a screen.
+ * Fetches HTML via getHtml() and image via getImage(), then saves them locally.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/download-artifacts.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+import fs from "fs/promises";
+import path from "path";
+
+console.log("Listing projects...");
+const projects = await stitch.projects();
+
+if (projects.length === 0) {
+  console.log("No projects found. Create a project and screen first.");
+  process.exit(0);
+}
+
+const p = projects[0];
+console.log(`Using project: ${p.id}`);
+
+console.log("Listing screens...");
+const screens = await p.screens();
+
+if (screens.length === 0) {
+  console.log(`No screens found in project ${p.id}.`);
+  process.exit(0);
+}
+
+const screen = screens[0];
+console.log(`Using screen: ${screen.id}`);
+
+const outDir = path.join(process.cwd(), "out");
+await fs.mkdir(outDir, { recursive: true });
+
+try {
+  // Download HTML
+  console.log("Fetching HTML URL...");
+  const htmlUrl = await screen.getHtml();
+  if (htmlUrl) {
+    console.log(`Downloading HTML from ${htmlUrl}...`);
+    const htmlResponse = await fetch(htmlUrl);
+    if (!htmlResponse.ok) throw new Error(`HTML fetch failed: ${htmlResponse.statusText}`);
+    const htmlCode = await htmlResponse.text();
+    const htmlPath = path.join(outDir, `${screen.id}.html`);
+    await fs.writeFile(htmlPath, htmlCode);
+    console.log(`✅ Saved HTML to ${htmlPath}`);
+  } else {
+    console.log("⚠️ No HTML URL available for this screen.");
+  }
+
+  // Download Image
+  console.log("Fetching Image URL...");
+  const imageUrl = await screen.getImage();
+  if (imageUrl) {
+    console.log(`Downloading Image from ${imageUrl}...`);
+    const imageResponse = await fetch(imageUrl);
+    if (!imageResponse.ok) throw new Error(`Image fetch failed: ${imageResponse.statusText}`);
+    const imageBuffer = await imageResponse.arrayBuffer();
+    const imagePath = path.join(outDir, `${screen.id}.jpeg`);
+    await fs.writeFile(imagePath, Buffer.from(imageBuffer));
+    console.log(`✅ Saved Image to ${imagePath}`);
+  } else {
+    console.log("⚠️ No Image URL available for this screen.");
+  }
+} catch (error) {
+  console.error("Failed to download artifacts:", error);
+}

--- a/packages/sdk/examples/get-project.ts
+++ b/packages/sdk/examples/get-project.ts
@@ -1,0 +1,33 @@
+/**
+ * Fetch detailed project metadata.
+ * Lists projects first, takes the first ID, and fetches full details.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/get-project.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+console.log("Listing projects...");
+const projects = await stitch.projects();
+
+if (projects.length === 0) {
+  console.log("No projects found. Create a project first to see its details.");
+  process.exit(0);
+}
+
+const projectId = projects[0].id;
+console.log(`Found ${projects.length} project(s).`);
+console.log(`Fetching details for project ID: ${projectId}...`);
+
+try {
+  // Use callTool to invoke get_project, since getProject is deliberately omitted from domain classes
+  const projectDetails = await stitch.callTool<any>("get_project", {
+    name: `projects/${projectId}`
+  });
+
+  console.log("Project Details retrieved successfully:");
+  console.log(JSON.stringify(projectDetails, null, 2));
+} catch (error) {
+  console.error(`Failed to fetch project details for ${projectId}:`, error);
+}

--- a/packages/sdk/examples/run-proxy.ts
+++ b/packages/sdk/examples/run-proxy.ts
@@ -1,0 +1,23 @@
+/**
+ * Run an MCP Proxy for Stitch, passing through requests over stdio.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/run-proxy.ts
+ */
+import "./_require-key.js";
+import { StitchProxy } from "@google/stitch-sdk";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+console.error("Starting Stitch MCP Proxy...");
+const proxy = new StitchProxy();
+const transport = new StdioServerTransport();
+
+// Handle graceful shutdown
+process.on("SIGINT", async () => {
+  console.error("Shutting down proxy...");
+  await proxy.close();
+  process.exit(0);
+});
+
+await proxy.start(transport);
+console.error("Proxy is ready. Waiting for requests on stdin...");


### PR DESCRIPTION
Creates 5 utility and advanced example snippets for the Stitch SDK:
- `_require-key.ts`: Shared helper to check for API key
- `run-proxy.ts`: Demonstrates proxying MCP requests over stdio
- `custom-client.ts`: Showcases custom `StitchToolClient` instantiation with OAuth credentials
- `get-project.ts`: Demonstrates using `stitch.callTool` to get project details
- `download-artifacts.ts`: Fetches HTML and image artifacts from a screen and saves them to a local `out/` directory

Fixes #26, #32, #35, #49, #55

---
*PR created automatically by Jules for task [2487685488555537974](https://jules.google.com/task/2487685488555537974) started by @davideast*