### PR TITLE
Refactor callTool to extract response parsing and throw typed StitchErrors

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -15,6 +15,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StitchConfigSchema, StitchConfig, StitchToolClientSpec } from './spec/client.js';
+import { StitchError, StitchErrorCode } from './spec/errors.js';
 import pkg from '../package.json' with { type: 'json' };
 
 /**
@@ -70,6 +71,44 @@ export class StitchToolClient implements StitchToolClientSpec {
     return headers;
   }
 
+  private parseToolResponse<T>(result: any, name: string): T {
+    if (result.isError) {
+      const errorText = (result.content as any[]).map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+
+      let code: StitchErrorCode = 'UNKNOWN_ERROR';
+      const lowerErrorText = errorText.toLowerCase();
+
+      if (lowerErrorText.includes('rate limit') || lowerErrorText.includes('429')) {
+        code = 'RATE_LIMITED';
+      } else if (lowerErrorText.includes('not found') || lowerErrorText.includes('404')) {
+        code = 'NOT_FOUND';
+      } else if (lowerErrorText.includes('permission') || lowerErrorText.includes('403')) {
+        code = 'PERMISSION_DENIED';
+      }
+
+      throw new StitchError({
+        code,
+        message: `Tool Call Failed [${name}]: ${errorText}`,
+        recoverable: code === 'RATE_LIMITED',
+      });
+    }
+
+    // Stitch specific parsing: Check structuredContent first, then JSON in text
+    const anyResult = result as any;
+    if (anyResult.structuredContent) return anyResult.structuredContent as T;
+
+    const textContent = (result.content as any[]).find((c: any) => c.type === 'text');
+    if (textContent && textContent.type === 'text') {
+      try {
+        return JSON.parse(textContent.text) as T;
+      } catch {
+        return textContent.text as unknown as T;
+      }
+    }
+
+    return anyResult as T;
+  }
+
   async connect() {
     if (this.isConnected) return;
 
@@ -104,25 +143,7 @@ export class StitchToolClient implements StitchToolClientSpec {
       { timeout: this.config.timeout }
     );
 
-    if (result.isError) {
-      const errorText = (result.content as any[]).map(c => (c.type === 'text' ? c.text : '')).join('');
-      throw new Error(`Tool Call Failed [${name}]: ${errorText}`);
-    }
-
-    // Stitch specific parsing: Check structuredContent first, then JSON in text
-    const anyResult = result as any;
-    if (anyResult.structuredContent) return anyResult.structuredContent as T;
-
-    const textContent = (result.content as any[]).find(c => c.type === 'text');
-    if (textContent && textContent.type === 'text') {
-      try {
-        return JSON.parse(textContent.text) as T;
-      } catch {
-        return textContent.text as unknown as T;
-      }
-    }
-
-    return anyResult as T;
+    return this.parseToolResponse<T>(result, name);
   }
 
   async listTools() {

--- a/packages/sdk/test/unit/client.test.ts
+++ b/packages/sdk/test/unit/client.test.ts
@@ -127,14 +127,44 @@ describe("StitchToolClient", () => {
       return client;
     }
 
-    it("should throw on isError response with tool name", async () => {
+    it("should throw UNKNOWN_ERROR on generic isError response with tool name", async () => {
       const client = createConnectedClient();
       client["client"].callTool = vi.fn().mockResolvedValue({
         isError: true,
         content: [{ type: "text", text: "something went wrong" }],
       });
       await expect(client.callTool("bad_tool", {}))
-        .rejects.toThrow("Tool Call Failed [bad_tool]");
+        .rejects.toMatchObject({
+          code: 'UNKNOWN_ERROR',
+          message: expect.stringContaining("Tool Call Failed [bad_tool]"),
+          recoverable: false,
+        });
+    });
+
+    it("should throw NOT_FOUND on 'project not found' error", async () => {
+      const client = createConnectedClient();
+      client["client"].callTool = vi.fn().mockResolvedValue({
+        isError: true,
+        content: [{ type: "text", text: "project not found" }],
+      });
+      await expect(client.callTool("bad_tool", {}))
+        .rejects.toMatchObject({
+          code: 'NOT_FOUND',
+          recoverable: false,
+        });
+    });
+
+    it("should throw RATE_LIMITED on 'rate limit exceeded' error", async () => {
+      const client = createConnectedClient();
+      client["client"].callTool = vi.fn().mockResolvedValue({
+        isError: true,
+        content: [{ type: "text", text: "rate limit exceeded" }],
+      });
+      await expect(client.callTool("bad_tool", {}))
+        .rejects.toMatchObject({
+          code: 'RATE_LIMITED',
+          recoverable: true,
+        });
     });
 
     it("should return structuredContent when present", async () => {


### PR DESCRIPTION
This PR refactors `StitchToolClient.callTool` to reduce cyclomatic complexity and improve error handling.

Changes:
1. Extracts response parsing logic into a new `parseToolResponse` method.
2. Replaces generic Errors thrown on tool call failure with typed `StitchError` instances, mapped to specific `StitchErrorCode`s (e.g., `RATE_LIMITED`, `NOT_FOUND`, `PERMISSION_DENIED`, `UNKNOWN_ERROR`) based on the error message text. Rate limiting errors are marked as `recoverable: true`.
3. Simplifies `callTool` to primarily handle the client call and delegate to `parseToolResponse`.
4. Adds new unit tests in `client.test.ts` to verify the mapping of specific error strings to their respective `StitchError` instances.

Fixes #46, #54, #56, #60

---
*PR created automatically by Jules for task [13105600022527685178](https://jules.google.com/task/13105600022527685178) started by @davideast*