### PR TITLE
test(sdk): add test coverage for proxy client, handlers, and domain classes

### DIFF
--- a/packages/sdk/test/proxy.test.ts
+++ b/packages/sdk/test/proxy.test.ts
@@ -15,6 +15,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StitchProxy } from '../src/proxy/index.js';
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { forwardToStitch, initializeStitchConnection } from '../src/proxy/client.js';
+import { registerListToolsHandler } from '../src/proxy/handlers/listTools.js';
+import { registerCallToolHandler } from '../src/proxy/handlers/callTool.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+
 
 // Mock fetch
 const globalFetch = global.fetch;
@@ -76,5 +82,191 @@ describe('StitchProxy', () => {
     // Since notifications/initialized is fire-and-forget but we mock fetch, it counts if called.
     expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(mockTransport.start).toHaveBeenCalled();
+  });
+});
+
+describe('Proxy Client Error Handling', () => {
+  let mockFetch: any;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.fetch = globalFetch;
+    vi.clearAllMocks();
+  });
+
+  it('forwardToStitch should throw Stitch API error on non-ok response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error'
+    } as Response);
+
+    await expect(forwardToStitch({ url: 'http://test', apiKey: 'test-key' } as any, 'testMethod')).rejects.toThrow('Stitch API error (500): Internal Server Error');
+  });
+
+  it('forwardToStitch should throw Stitch RPC error on JSON-RPC error payload', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ error: { message: 'Method not found' } })
+    } as Response);
+
+    await expect(forwardToStitch({ url: 'http://test', apiKey: 'test-key' } as any, 'testMethod')).rejects.toThrow('Stitch RPC error: Method not found');
+  });
+
+  it('initializeStitchConnection should catch and log rejected fetch on notifications/initialized', async () => {
+    // initialize request
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: {} })
+    } as Response);
+
+    // notifications/initialized (rejects)
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    // tools/list
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { tools: [] } })
+    } as Response);
+
+    const ctx = {
+      config: { url: 'http://test', apiKey: 'test-key', name: 'test', version: '1.0' },
+      remoteTools: []
+    } as any;
+
+    await expect(initializeStitchConnection(ctx)).resolves.not.toThrow();
+
+    // allow the fire-and-forget promise to settle
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(console.error).toHaveBeenCalledWith(
+      '[stitch-proxy] Failed to send initialized notification:',
+      expect.any(Error)
+    );
+  });
+});
+
+describe('Proxy Handlers', () => {
+  let mockFetch: any;
+  let mockServer: any;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Mock for Server.setRequestHandler
+    mockServer = {
+      handlers: new Map(),
+      setRequestHandler(schema: any, handler: any) {
+        this.handlers.set(schema, handler);
+      }
+    };
+  });
+
+  afterEach(() => {
+    global.fetch = globalFetch;
+    vi.clearAllMocks();
+  });
+
+  it('registerListToolsHandler should invoke refreshTools and return cached tools', async () => {
+    const ctx = {
+      config: { url: 'http://test', apiKey: 'test-key' },
+      remoteTools: []
+    } as any;
+
+    registerListToolsHandler(mockServer as any, ctx);
+
+    const handler = mockServer.handlers.get(ListToolsRequestSchema);
+    expect(handler).toBeDefined();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { tools: [{ name: 'refreshed-tool' }] } })
+    } as Response);
+
+    const result = await handler({} as any, {} as any);
+
+    expect(result).toEqual({ tools: [{ name: 'refreshed-tool' }] });
+    expect(ctx.remoteTools).toEqual([{ name: 'refreshed-tool' }]);
+  });
+
+  it('registerListToolsHandler should handle fetch error gracefully', async () => {
+    const ctx = {
+      config: { url: 'http://test', apiKey: 'test-key' },
+      remoteTools: [{ name: 'existing-tool' }]
+    } as any;
+
+    registerListToolsHandler(mockServer as any, ctx);
+
+    const handler = mockServer.handlers.get(ListToolsRequestSchema);
+    expect(handler).toBeDefined();
+
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await handler({} as any, {} as any);
+
+    // Should return existing tools if refresh fails
+    expect(result).toEqual({ tools: [{ name: 'existing-tool' }] });
+    expect(console.error).toHaveBeenCalledWith(
+      '[stitch-proxy] Failed to refresh tools:',
+      expect.any(Error)
+    );
+  });
+
+  it('registerCallToolHandler should invoke forwardToStitch and return result', async () => {
+    const ctx = {
+      config: { url: 'http://test', apiKey: 'test-key' },
+      remoteTools: []
+    } as any;
+
+    registerCallToolHandler(mockServer as any, ctx);
+
+    const handler = mockServer.handlers.get(CallToolRequestSchema);
+    expect(handler).toBeDefined();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { content: [{ type: 'text', text: 'success' }] } })
+    } as Response);
+
+    const request = {
+      params: { name: 'test_tool', arguments: { arg1: 'value1' } }
+    };
+
+    const result = await handler(request as any, {} as any);
+
+    expect(result).toEqual({ content: [{ type: 'text', text: 'success' }] });
+    expect(console.error).toHaveBeenCalledWith('[stitch-proxy] Calling tool: test_tool');
+  });
+
+  it('registerCallToolHandler should return isError: true on failure', async () => {
+    const ctx = {
+      config: { url: 'http://test', apiKey: 'test-key' },
+      remoteTools: []
+    } as any;
+
+    registerCallToolHandler(mockServer as any, ctx);
+
+    const handler = mockServer.handlers.get(CallToolRequestSchema);
+    expect(handler).toBeDefined();
+
+    mockFetch.mockRejectedValueOnce(new Error('RPC failed'));
+
+    const request = {
+      params: { name: 'test_tool', arguments: { arg1: 'value1' } }
+    };
+
+    const result = await handler(request as any, {} as any);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Error calling test_tool: RPC failed');
+    expect(console.error).toHaveBeenCalledWith('[stitch-proxy] Tool call failed: RPC failed');
   });
 });

--- a/packages/sdk/test/unit/sdk.test.ts
+++ b/packages/sdk/test/unit/sdk.test.ts
@@ -87,6 +87,25 @@ describe("SDK Unit Tests", () => {
       expect(result).toBe("https://api.example.com/image.png");
     });
 
+
+    it("getHtml should fallback to empty string when raw.htmlCode.downloadUrl is missing", async () => {
+      const screen = new Screen(mockClient, { id: "screen-123", name: "Login", projectId });
+
+      // Mock missing htmlCode / downloadUrl
+      (mockClient.callTool as Mock).mockResolvedValue({
+        htmlCode: {}
+      });
+
+      const result = await screen.getHtml();
+
+      expect(mockClient.callTool).toHaveBeenCalledWith("get_screen", {
+        projectId: projectId,
+        screenId: "screen-123",
+        name: "projects/proj-123/screens/screen-123",
+      });
+      expect(result).toBe("");
+    });
+
     it("getHtml should throw StitchError on failure", async () => {
       const screen = new Screen(mockClient, { id: "screen-123", name: "Login", projectId });
       (mockClient.callTool as Mock).mockRejectedValue(new Error("Network failure"));
@@ -198,6 +217,29 @@ describe("SDK Unit Tests", () => {
       expect(result.projectId).toBe(projectId);
     });
 
+
+    it("generate should handle missing design.screens in outputComponents gracefully", async () => {
+      const project = new Project(mockClient, projectId);
+
+      // Mock with missing screens array
+      (mockClient.callTool as Mock).mockResolvedValue({
+        outputComponents: [
+          {
+            design: {
+              // screens is missing
+            },
+          },
+        ],
+        projectId: projectId,
+        sessionId: "session-1",
+      });
+
+      // Based on the Screen class constructor, if it's passed undefined, it might throw
+      // or if it tries to access missing screens it might throw TypeError.
+      // The generated code in project.ts wraps the try block and throws StitchError.
+      await expect(project.generate("test")).rejects.toThrow();
+    });
+
     it("screens should list screens and return Screen instances", async () => {
       const project = new Project(mockClient, projectId);
       const mockResponse = {
@@ -219,6 +261,22 @@ describe("SDK Unit Tests", () => {
       expect(result[0]).toBeInstanceOf(Screen);
       expect(result[1]).toBeInstanceOf(Screen);
       expect(result[0].id).toBe("s1");
+    });
+
+
+    it("screens should return [] when returned data has no screens array", async () => {
+      const project = new Project(mockClient, projectId);
+
+      // Mock with missing screens array
+      (mockClient.callTool as Mock).mockResolvedValue({});
+
+      const result = await project.screens();
+
+      expect(mockClient.callTool).toHaveBeenCalledWith("list_screens", {
+        projectId: projectId
+      });
+
+      expect(result).toEqual([]);
     });
 
     it("generate should throw StitchError on failure", async () => {


### PR DESCRIPTION
This PR adds missing unit test coverage across the `@google/stitch-sdk` proxy client, proxy handlers, and generated domain classes.

**Changes included:**
* **Proxy Client (`proxy.test.ts`)**: Added tests to ensure `forwardToStitch` correctly handles and throws on non-ok API responses and JSON-RPC error payloads. Also added tests to verify that `initializeStitchConnection` gracefully catches and logs errors when the `notifications/initialized` endpoint fails without throwing.
* **Proxy Handlers (`proxy.test.ts`)**: Added tests validating that `tools/list` invokes `refreshTools` and returns cached tools, and that `tools/call` successfully forwards the request or returns an `{ isError: true }` object on failure.
* **Domain Classes (`unit/sdk.test.ts`)**: Added branch coverage for edge cases, including `project.generate()` handling missing `design.screens`, `project.screens()` returning an empty array when `screens` is missing, and `screen.getHtml()` gracefully falling back to an empty string when the cached URL is unavailable.

Fixes #50, #51, #57

---
*PR created automatically by Jules for task [16683464579931428235](https://jules.google.com/task/16683464579931428235) started by @davideast*