### PR TITLE
feat(sdk): add capability-focused example snippets

### DIFF
--- a/packages/sdk/examples/_require-key.ts
+++ b/packages/sdk/examples/_require-key.ts
@@ -1,0 +1,5 @@
+if (!process.env.STITCH_API_KEY) {
+  console.log("⏭️  Set STITCH_API_KEY to run this snippet.");
+  console.log("   STITCH_API_KEY=your-key bun", process.argv[1]);
+  process.exit(0);
+}

--- a/packages/sdk/examples/extract-symbols.ts
+++ b/packages/sdk/examples/extract-symbols.ts
@@ -1,0 +1,57 @@
+/**
+ * Fetch HTML from a screen and parse it for Material Symbols usage.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/extract-symbols.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+const projects = await stitch.projects();
+if (projects.length === 0) {
+  console.log("❌ No projects found. Cannot generate a screen.");
+  process.exit(1);
+}
+const project = projects[0];
+
+console.log(`🎨 Generating a screen in project ${project.id}...`);
+const screen = await project.generate("A dashboard with many Material Design icons");
+console.log(`✅ Screen generated: ${screen.id}`);
+
+const htmlOrUrl = await screen.getHtml();
+let html = htmlOrUrl;
+
+// If getHtml() returns a download URL, fetch the actual HTML content
+if (htmlOrUrl.startsWith("http")) {
+  console.log(`📥 Fetching HTML from ${htmlOrUrl}...`);
+  const response = await fetch(htmlOrUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch HTML: ${response.statusText}`);
+  }
+  html = await response.text();
+} else {
+  console.log(`📥 Using HTML directly (length: ${html.length})`);
+}
+
+// Parse Google Fonts links for Material Symbols
+console.log("\n🔍 Checking for Material Symbols font import...");
+if (html.includes("fonts.googleapis.com/css2?family=Material+Symbols")) {
+  console.log("✅ Found Material Symbols font import!");
+} else {
+  console.log("❌ No Material Symbols font import found.");
+}
+
+// Parse Material Symbols usage
+console.log("\n🔍 Parsing Material Symbols usage...");
+// Look for <span class="... material-symbols-outlined ...">icon_name</span>
+const matches = Array.from(
+  html.matchAll(/<span[^>]*class="[^"]*material-symbols-[^"]*"[^>]*>([^<]+)<\/span>/g)
+);
+
+if (matches.length > 0) {
+  const uniqueIcons = new Set(matches.map(m => m[1].trim()));
+  console.log(`✅ Found ${uniqueIcons.size} unique Material Symbol(s):`);
+  uniqueIcons.forEach(icon => console.log(`  - ${icon}`));
+} else {
+  console.log("❌ No Material Symbols usage found in HTML.");
+}

--- a/packages/sdk/examples/extract-tailwind.ts
+++ b/packages/sdk/examples/extract-tailwind.ts
@@ -1,0 +1,57 @@
+/**
+ * Fetch HTML from a screen and parse out the Tailwind configuration
+ * and Google Fonts links.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/extract-tailwind.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+const projects = await stitch.projects();
+if (projects.length === 0) {
+  console.log("❌ No projects found. Cannot generate a screen.");
+  process.exit(1);
+}
+const project = projects[0];
+
+console.log(`🎨 Generating a screen in project ${project.id}...`);
+const screen = await project.generate("A modern login page with a custom Tailwind theme");
+console.log(`✅ Screen generated: ${screen.id}`);
+
+const htmlOrUrl = await screen.getHtml();
+let html = htmlOrUrl;
+
+// If getHtml() returns a download URL, fetch the actual HTML content
+if (htmlOrUrl.startsWith("http")) {
+  console.log(`📥 Fetching HTML from ${htmlOrUrl}...`);
+  const response = await fetch(htmlOrUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch HTML: ${response.statusText}`);
+  }
+  html = await response.text();
+} else {
+  console.log(`📥 Using HTML directly (length: ${html.length})`);
+}
+
+// Parse out the Tailwind configuration
+console.log("🔍 Parsing Tailwind config...");
+const configMatch = html.match(/<script id="tailwind-config">([\s\S]*?)<\/script>/);
+
+if (configMatch) {
+  console.log("✅ Found Tailwind config!");
+  console.log(configMatch[1].trim());
+} else {
+  console.log("❌ No Tailwind config found.");
+}
+
+// Parse Google Fonts links
+console.log("🔍 Parsing Google Fonts links...");
+const fontsMatches = html.match(/<link[^>]*fonts\.googleapis\.com[^>]*>/g) || [];
+
+if (fontsMatches.length > 0) {
+  console.log(`✅ Found ${fontsMatches.length} Google Fonts link(s):`);
+  fontsMatches.forEach(link => console.log(`  - ${link}`));
+} else {
+  console.log("❌ No Google Fonts links found.");
+}

--- a/packages/sdk/examples/get-screen.ts
+++ b/packages/sdk/examples/get-screen.ts
@@ -1,0 +1,37 @@
+/**
+ * Fetch a specific screen by ID using project.getScreen(id)
+ * and log its properties.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/get-screen.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+const projects = await stitch.projects();
+if (projects.length === 0) {
+  console.log("❌ No projects found.");
+  process.exit(1);
+}
+
+const project = projects[0];
+console.log(`📂 Using project: ${project.id}`);
+
+console.log("🔍 Fetching screens in project...");
+const screens = await project.screens();
+if (screens.length === 0) {
+  console.log("❌ No screens found in project. Please generate one first.");
+  process.exit(1);
+}
+
+const firstScreenId = screens[0].id;
+console.log(`✅ Found screens. Retrieving screen ${firstScreenId} directly...`);
+
+const retrievedScreen = await project.getScreen(firstScreenId);
+
+console.log("\n📱 Screen Details:");
+console.log(`   Screen ID:  ${retrievedScreen.id}`);
+console.log(`   Project ID: ${retrievedScreen.projectId}`);
+console.log(`   Data Name:  ${retrievedScreen.data?.name}`);
+console.log(`   HTML URL:   ${retrievedScreen.data?.htmlCode?.downloadUrl || "N/A"}`);
+console.log(`   Image URL:  ${retrievedScreen.data?.screenshot?.downloadUrl || "N/A"}`);

--- a/packages/sdk/examples/list-tools.ts
+++ b/packages/sdk/examples/list-tools.ts
@@ -1,0 +1,25 @@
+/**
+ * Call stitch.listTools() to enumerate available MCP tools and log
+ * their names, descriptions, and parameter schemas.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/list-tools.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+console.log("🛠️  Retrieving available tools via stitch.listTools()...\n");
+const toolsResponse = await stitch.listTools();
+
+const tools = toolsResponse.tools;
+console.log(`✅ Found ${tools.length} available tools:\n`);
+
+for (const tool of tools) {
+  console.log(`🔹 Tool: ${tool.name}`);
+  console.log(`   Description: ${tool.description}`);
+  if (tool.inputSchema) {
+    console.log("   Input Schema:");
+    console.log(JSON.stringify(tool.inputSchema, null, 2).replace(/^/gm, "     "));
+  }
+  console.log("");
+}

--- a/packages/sdk/examples/retrieve-screen.ts
+++ b/packages/sdk/examples/retrieve-screen.ts
@@ -1,0 +1,32 @@
+/**
+ * Demonstrate direct screen retrieval using project.getScreen(screenId)
+ * instead of listing all screens.
+ *
+ * Usage:
+ *   STITCH_API_KEY=your-key bun packages/sdk/examples/retrieve-screen.ts
+ */
+import "./_require-key.js";
+import { stitch } from "@google/stitch-sdk";
+
+const projects = await stitch.projects();
+if (projects.length === 0) {
+  console.log("❌ No projects found.");
+  process.exit(1);
+}
+const project = projects[0];
+
+console.log(`🎨 Generating a screen in project ${project.id}...`);
+const generatedScreen = await project.generate("A simple primary button");
+console.log(`✅ Screen generated. ID: ${generatedScreen.id}`);
+console.log(`   Initial data name: ${generatedScreen.data?.name}`);
+
+console.log(`\n🔍 Fetching screen directly via project.getScreen("${generatedScreen.id}")...`);
+const retrievedScreen = await project.getScreen(generatedScreen.id);
+console.log(`✅ Retrieved screen. ID: ${retrievedScreen.id}`);
+console.log(`   Retrieved data name: ${retrievedScreen.data?.name}`);
+
+if (generatedScreen.id === retrievedScreen.id) {
+  console.log("\n✅ Success! Directly retrieved screen ID matches the generated screen.");
+} else {
+  console.log("\n❌ Mismatch in screen IDs.");
+}


### PR DESCRIPTION
This PR introduces a suite of capability-focused example snippets for the Stitch SDK, addressing multiple tracked issues in a single logical changeset.

### Additions:
1. **`extract-tailwind.ts`** (#22): Demonstrates generating a screen, fetching its HTML directly via `screen.getHtml()`, and using regular expressions to extract the `<script id="tailwind-config">` block and Google Fonts `<link>` tags.
2. **`retrieve-screen.ts`** (#25): Shows a workflow where a screen is generated, its ID is captured, and then it is immediately fetched again using `project.getScreen(id)` to verify direct access.
3. **`list-tools.ts`** (#27, #29): Merges the tool discovery and introspection requirements. It calls `stitch.listTools()` to iterate through all available MCP tools, logging their names, descriptions, and pretty-printing their JSON input schemas.
4. **`get-screen.ts`** (#28): Illustrates how to list existing projects and screens, select the first available screen, and fetch its detailed properties (like `screenId`, `projectId`, and data names) directly.
5. **`extract-symbols.ts`** (#33): Generates a screen, fetches its HTML, and uses RegEx to detect the presence of the Material Symbols font import and uniquely log all used `<span class="material-symbols-outlined">` icons.
6. **`_require-key.ts`**: A shared helper imported by all examples to gracefully exit with usage instructions if `STITCH_API_KEY` is not set in the environment.

### Technical Details:
- All snippets use top-level `await` and ESM imports, correctly resolving `_require-key.js`.
- Error handling is included to manage scenarios where no projects or screens are available for the read-only operations.
- Direct string returns from `screen.getHtml()` are used appropriately without unnecessary network fetches, as verified against the SDK's domain class implementations.

Fixes #22, #25, #27, #28, #29, #33

---
*PR created automatically by Jules for task [4469095711264982829](https://jules.google.com/task/4469095711264982829) started by @davideast*