### PR TITLE
fix: use variantCount instead of numVariants in generate-variants example

### DIFF
--- a/packages/sdk/examples/generate-variants.ts
+++ b/packages/sdk/examples/generate-variants.ts
@@ -37,7 +37,7 @@ if (!targetScreen || !targetProject) {
 console.log(`✅ Found base screen ${targetScreen.id} in project ${targetProject.id}`);
 
 const variantsPrompt = "Change the button style to outline";
-const variantOptions = { numVariants: 3 };
+const variantOptions = { variantCount: 3 };
 
 console.log(`\n🎨 Generating variants with prompt: "${variantsPrompt}"...`);
 console.log("   (This may take up to a minute)");

--- a/packages/sdk/test/unit/examples.test.ts
+++ b/packages/sdk/test/unit/examples.test.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Contract tests: ensure example files use correct API field names.
+ * These are static analysis tests — they parse example source code
+ * and verify correctness without executing against the live API.
+ */
+describe("Example Contract Tests", () => {
+  const examplesDir = resolve(import.meta.dirname, "../../examples");
+
+  describe("generate-variants.ts", () => {
+    const source = readFileSync(
+      resolve(examplesDir, "generate-variants.ts"),
+      "utf8"
+    );
+
+    it("should use 'variantCount' not 'numVariants' in variantOptions", () => {
+      // The API schema (VariantOptions) uses 'variantCount', not 'numVariants'.
+      expect(source).not.toContain("numVariants");
+      expect(source).toContain("variantCount");
+    });
+  });
+});


### PR DESCRIPTION
- Fix incorrect field name in generate-variants.ts (numVariants → variantCount) to match the API's VariantOptions schema
- Add contract test (examples.test.ts) that statically verifies example files use correct API field names