### PR TITLE
fix: retry callTool once on transient network errors

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -148,6 +148,11 @@ export class StitchToolClient implements StitchToolClientSpec {
   }
 
   private async doConnect() {
+    // Close existing transport before creating a new one to prevent resource leaks
+    if (this.transport) {
+      await this.transport.close().catch(() => {});
+    }
+
     // Create transport with auth headers injected per-instance (no global fetch mutation)
     this.transport = new StreamableHTTPClientTransport(
       new URL(this.config.baseUrl),

--- a/packages/sdk/test/unit/client.test.ts
+++ b/packages/sdk/test/unit/client.test.ts
@@ -338,6 +338,30 @@ describe("StitchToolClient", () => {
       expect(client["client"].callTool).toHaveBeenCalledTimes(1);
     });
 
+    it("should close old transport before reconnecting", async () => {
+      const client = new StitchToolClient({ apiKey: "k" });
+      client["isConnected"] = true;
+
+      // Set up a mock old transport with a close spy
+      const oldTransportClose = vi.fn().mockResolvedValue(undefined);
+      client["transport"] = { close: oldTransportClose } as any;
+
+      let callCount = 0;
+      client["client"].callTool = vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new TypeError("fetch failed");
+        }
+        return {
+          isError: false,
+          content: [{ type: "text", text: '{"ok":true}' }],
+        };
+      });
+
+      await client.callTool("list_projects", {});
+      expect(oldTransportClose).toHaveBeenCalledTimes(1);
+    });
+
     it("should throw after retry also fails", async () => {
       const client = new StitchToolClient({ apiKey: "k" });
       client["isConnected"] = true;


### PR DESCRIPTION
Fixes #114

## Summary

When concurrent `callTool()` requests run (e.g. variant generation with Pro model), the Stitch server occasionally closes the socket, causing `TypeError: fetch failed`. The SDK surfaces this as an unrecoverable error with no retry.

**Changes:**
- Add single retry with reconnect for transient network errors (`fetch failed`, `ECONNRESET`, socket errors)
- Skip retry for non-idempotent tools (`generate_screen_from_text`, `edit_screens`, `generate_variants`, `create_project`) — these are marked `destructiveHint: true, idempotentHint: false` in the tools manifest and their descriptions say "DO NOT RETRY"
- Close old transport before creating a new one on reconnect to prevent resource leaks
- Application-level errors (`StitchError` from `isError` responses) are never retried

## Retry behavior

| Tool type | On network error | Examples |
|-----------|-----------------|----------|
| Read (idempotent) | Reconnect + retry once | `list_projects`, `get_screen`, `list_screens` |
| Write (non-idempotent) | Throw immediately | `generate_screen_from_text`, `edit_screens`, `generate_variants`, `create_project` |

## Reproduction

3 concurrent `generate_variants` calls with `GEMINI_3_PRO`:
- **Before**: 2/3 succeed, 1 fails with `fetch failed`
- **After**: read operations recover via retry; write operations still fail fast (by design)

## Test plan

- [x] Retry succeeds on second attempt for idempotent tools
- [x] Application-level errors (NOT_FOUND etc.) are NOT retried
- [x] `generate_screen_from_text` is NOT retried on network error
- [x] `create_project` is NOT retried on network error
- [x] Old transport is closed before reconnecting
- [x] Retry that also fails throws the original error
- [x] All 120 tests pass (`npm run test`)
- [x] Script tests pass (`npm run test:scripts`)
- [x] Smoke tests pass (`npm run test:smoke`)
- [x] No new tsc errors in modified files
- [x] Formatted with Prettier