### PR TITLE
fix: use .find() for outputComponents projection instead of hardcoded [0]

### DIFF
--- a/packages/sdk/generated/domain-map.json
+++ b/packages/sdk/generated/domain-map.json
@@ -43,7 +43,19 @@
         }
       },
       "parentField": "projectId",
-      "idField": "screenId"
+      "idField": "screenId",
+      "accessors": [
+        {
+          "method": "getDesignMarkdown",
+          "returns": "string",
+          "projection": [
+            { "prop": "theme" },
+            { "prop": "designMd" }
+          ],
+          "fallback": "\"\"",
+          "description": "Returns the cached design system markdown from the generation response.\nOnly available on screens returned by generate() or edit(), not from get_screen."
+        }
+      ]
     }
   },
   "bindings": [
@@ -103,7 +115,7 @@
         "projection": [
           {
             "prop": "outputComponents",
-            "index": 0
+            "find": "design"
           },
           {
             "prop": "design"
@@ -144,7 +156,7 @@
         "projection": [
           {
             "prop": "outputComponents",
-            "index": 0
+            "find": "design"
           },
           {
             "prop": "design"

--- a/packages/sdk/generated/src/index.ts
+++ b/packages/sdk/generated/src/index.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-19T18:56:19.253Z
+        domain-map.json     (sha256:ec71dbf8ccdf...)
+Generated: 2026-03-22T08:09:04.914Z
  */
 export { Stitch } from "./stitch.js";
 export { Project } from "./project.js";

--- a/packages/sdk/generated/src/project.ts
+++ b/packages/sdk/generated/src/project.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-19T18:56:19.253Z
+        domain-map.json     (sha256:ec71dbf8ccdf...)
+Generated: 2026-03-22T08:09:04.914Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";
@@ -37,7 +37,7 @@ export class Project {
     async generate(prompt: string, deviceType?: "DEVICE_TYPE_UNSPECIFIED" | "MOBILE" | "DESKTOP" | "TABLET" | "AGNOSTIC", modelId?: "MODEL_ID_UNSPECIFIED" | "GEMINI_3_PRO" | "GEMINI_3_FLASH"): Promise<Screen> {
         try {
           const raw = await this.client.callTool<any>("generate_screen_from_text", { projectId: this.projectId, prompt, deviceType, modelId });
-          return new Screen(this.client, { ...raw.outputComponents[0].design.screens[0], projectId: this.projectId });
+          return new Screen(this.client, { ...raw.outputComponents.find((c: any) => c.design).design.screens[0], projectId: this.projectId });
         } catch (error) {
           throw StitchError.fromUnknown(error);
         }

--- a/packages/sdk/generated/src/screen.ts
+++ b/packages/sdk/generated/src/screen.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-19T18:56:19.253Z
+        domain-map.json     (sha256:ec71dbf8ccdf...)
+Generated: 2026-03-22T08:09:04.914Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";
@@ -38,7 +38,7 @@ export class Screen {
     async edit(prompt: string, deviceType?: "DEVICE_TYPE_UNSPECIFIED" | "MOBILE" | "DESKTOP" | "TABLET" | "AGNOSTIC", modelId?: "MODEL_ID_UNSPECIFIED" | "GEMINI_3_PRO" | "GEMINI_3_FLASH"): Promise<Screen> {
         try {
           const raw = await this.client.callTool<any>("edit_screens", { projectId: this.projectId, selectedScreenIds: [this.screenId], prompt, deviceType, modelId });
-          return new Screen(this.client, { ...raw.outputComponents[0].design.screens[0], projectId: this.projectId });
+          return new Screen(this.client, { ...raw.outputComponents.find((c: any) => c.design).design.screens[0], projectId: this.projectId });
         } catch (error) {
           throw StitchError.fromUnknown(error);
         }
@@ -87,5 +87,13 @@ export class Screen {
         } catch (error) {
           throw StitchError.fromUnknown(error);
         }
+    }
+
+    /**
+     * Returns the cached design system markdown from the generation response.
+     * Only available on screens returned by generate() or edit(), not from get_screen.
+     */
+    getDesignMarkdown(): string {
+        return this.data?.theme?.designMd || "";
     }
 }

--- a/packages/sdk/generated/src/stitch.ts
+++ b/packages/sdk/generated/src/stitch.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-19T18:56:19.253Z
+        domain-map.json     (sha256:ec71dbf8ccdf...)
+Generated: 2026-03-22T08:09:04.914Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/tool-definitions.ts
+++ b/packages/sdk/generated/src/tool-definitions.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-19T18:56:19.253Z
+        domain-map.json     (sha256:ec71dbf8ccdf...)
+Generated: 2026-03-22T08:09:04.914Z
  */
 /** JSON Schema property descriptor for a tool parameter. */
 export interface ToolPropertySchema {

--- a/packages/sdk/generated/stitch-sdk.lock
+++ b/packages/sdk/generated/stitch-sdk.lock
@@ -7,15 +7,15 @@
     "serverUrl": "https://stitch.googleapis.com/mcp"
   },
   "generated": {
-    "generatedAt": "2026-03-19T18:56:19.351Z",
-    "sourceHash": "sha256:06c97f633a04942efd348aa1634356c9f5f0fd3e16d33802bffe7e8e9a650905",
+    "generatedAt": "2026-03-22T08:08:46.506Z",
+    "sourceHash": "sha256:42fa5072857be5edd7ac90555d71190fd91754e4a3754a140d95d5a20f1cc52c",
     "manifestHash": "sha256:1f84b31604f95580325952f0c150a3e045543fad2596e9a4d8ed15c07e0cbf9b",
-    "domainMapHash": "sha256:99b823ad930620c571a9443c7b956f90b092d626be9ce2319d7a7bfe3a2e3db4",
+    "domainMapHash": "sha256:ec71dbf8ccdf2c8fe1fc80984b2efd4224cfa0faaef81a522927d104a201e2ed",
     "fileCount": 5
   },
   "domainMap": {
-    "generatedAt": "2026-03-19T18:56:19.351Z",
-    "sourceHash": "sha256:99b823ad930620c571a9443c7b956f90b092d626be9ce2319d7a7bfe3a2e3db4",
+    "generatedAt": "2026-03-22T08:08:46.506Z",
+    "sourceHash": "sha256:ec71dbf8ccdf2c8fe1fc80984b2efd4224cfa0faaef81a522927d104a201e2ed",
     "manifestHash": "sha256:1f84b31604f95580325952f0c150a3e045543fad2596e9a4d8ed15c07e0cbf9b",
     "classCount": 3,
     "bindingCount": 9

--- a/packages/sdk/test/unit/sdk.test.ts
+++ b/packages/sdk/test/unit/sdk.test.ts
@@ -113,6 +113,25 @@ describe("SDK Unit Tests", () => {
       await expect(screen.getHtml()).rejects.toThrow("Network failure");
     });
 
+    it("edit should find screen when designSystem is at outputComponents[0]", async () => {
+      const screen = new Screen(mockClient, screenData);
+
+      (mockClient.callTool as Mock).mockResolvedValue({
+        outputComponents: [
+          { designSystem: { designSystem: "...", name: "ds", version: "1" } },
+          { design: { screens: [{ id: "edited-real", htmlCode: "<div>Edited</div>", projectId }] } },
+          { text: "Edited your screen" },
+        ],
+        projectId,
+        sessionId: "session-1",
+      });
+
+      const edited = await screen.edit("Make it dark");
+
+      expect(edited).toBeInstanceOf(Screen);
+      expect(edited.id).toBe("edited-real");
+    });
+
     it("edit should call edit_screens and return new Screen", async () => {
       const screen = new Screen(mockClient, screenData);
 
@@ -229,6 +248,27 @@ describe("SDK Unit Tests", () => {
       expect(result.projectId).toBe(projectId);
     });
 
+
+    it("generate should find screen when designSystem is at outputComponents[0]", async () => {
+      const project = new Project(mockClient, projectId);
+
+      (mockClient.callTool as Mock).mockResolvedValue({
+        outputComponents: [
+          { designSystem: { designSystem: "...", name: "ds", version: "1" } },
+          { design: { screens: [{ id: "real-screen-1", htmlCode: { downloadUrl: "https://example.com" }, projectId }], theme: {} } },
+          { text: "Here is your screen" },
+          { suggestion: "Make it dark" },
+        ],
+        projectId,
+        sessionId: "session-1",
+      });
+
+      const result = await project.generate("A card");
+
+      expect(result).toBeInstanceOf(Screen);
+      expect(result.id).toBe("real-screen-1");
+      expect(result.projectId).toBe(projectId);
+    });
 
     it("generate should handle missing design.screens in outputComponents gracefully", async () => {
       const project = new Project(mockClient, projectId);

--- a/scripts/generate-sdk.ts
+++ b/scripts/generate-sdk.ts
@@ -170,7 +170,9 @@ export function emitProjection(steps: ProjectionStep[], rawVar: string = "raw"):
   let code = rawVar;
   for (const step of steps) {
     code += `.${step.prop}`;
-    if (step.index !== undefined) {
+    if (step.find) {
+      code += `.find((c: any) => c.${step.find})`;
+    } else if (step.index !== undefined) {
       code += `[${step.index}]`;
     }
   }
@@ -602,6 +604,20 @@ async function main() {
           parameters: [{ name: "id", type: "string" }],
           docs: [{ description: factory.description || `Create a ${factory.returns} from an ID.` }],
           statements: [`return new ${factory.returns}(this.client, id);`],
+        });
+      }
+    }
+
+    // Accessor methods (read from this.data, no API call)
+    if (config.accessors) {
+      for (const accessor of config.accessors) {
+        const cacheExpr = emitCacheProjection(accessor.projection);
+        const fallback = accessor.fallback !== undefined ? accessor.fallback : '""';
+        cls.addMethod({
+          name: accessor.method,
+          returnType: accessor.returns,
+          docs: [{ description: accessor.description || accessor.method }],
+          statements: [`return ${cacheExpr} || ${fallback};`],
         });
       }
     }

--- a/scripts/ir-schema.ts
+++ b/scripts/ir-schema.ts
@@ -36,11 +36,16 @@ export const ProjectionStep = z.object({
   index: z.number().int().min(0).optional(),
   /** Flatten all items via flatMap (replaces [*] glob) */
   each: z.boolean().optional(),
+  /** Find the first array element that has this property (replaces brittle index) */
+  find: z.string().optional(),
   /** Alternate property name if primary is missing */
   fallback: z.string().optional(),
 }).refine(
   data => !(data.index !== undefined && data.each),
   { message: "Cannot use both 'index' and 'each' on the same step" }
+).refine(
+  data => !(data.find && data.each),
+  { message: "Cannot use both 'find' and 'each' on the same step" }
 );
 export type ProjectionStep = z.infer<typeof ProjectionStep>;
 
@@ -128,6 +133,21 @@ export const FactorySpec = z.object({
 });
 export type FactorySpec = z.infer<typeof FactorySpec>;
 
+/** A local accessor that reads a value from this.data without an API call. */
+export const AccessorSpec = z.object({
+  /** Method name */
+  method: z.string(),
+  /** Return type (e.g. "string") */
+  returns: z.string(),
+  /** Projection path into this.data */
+  projection: z.array(ProjectionStep),
+  /** Fallback value when projection yields undefined */
+  fallback: z.string().optional(),
+  /** Description for JSDoc */
+  description: z.string().optional(),
+});
+export type AccessorSpec = z.infer<typeof AccessorSpec>;
+
 // ── Class Config ──────────────────────────────────────────────
 
 export const DomainClassConfig = z.object({
@@ -140,6 +160,8 @@ export const DomainClassConfig = z.object({
   idField: z.string().optional(),
   /** Local factory methods that create child instances without API calls */
   factories: z.array(FactorySpec).optional(),
+  /** Local accessor methods that read from this.data without API calls */
+  accessors: z.array(AccessorSpec).optional(),
 });
 export type DomainClassConfig = z.infer<typeof DomainClassConfig>;
 

--- a/scripts/test/generate-sdk.test.ts
+++ b/scripts/test/generate-sdk.test.ts
@@ -72,6 +72,18 @@ describe("emitProjection", () => {
     expect(emitProjection(steps)).toBe("raw.a[0].b.c[1]");
   });
 
+  test("find step → .find() pattern", () => {
+    const steps: ProjectionStep[] = [
+      { prop: "outputComponents", find: "design" },
+      { prop: "design" },
+      { prop: "screens", index: 0 },
+    ];
+    const result = emitProjection(steps);
+    expect(result).toContain(".find(");
+    expect(result).toContain("design");
+    expect(result).toContain(".screens[0]");
+  });
+
   test("single each → flatMap pattern", () => {
     const steps: ProjectionStep[] = [
       { prop: "outputComponents", each: true },


### PR DESCRIPTION
Fixes #143

## Summary

- `generate()` and `edit()` crash because `outputComponents[0]` is now `designSystem`, not screen data
- Adds `find` field to `ProjectionStep` IR — emits `.find((c) => c.design)` instead of brittle `[0]`
- Adds `AccessorSpec` to codegen pipeline so `getDesignMarkdown()` is generated, not handwritten

## What changed

| Layer | File | Change |
|-------|------|--------|
| IR Schema | `scripts/ir-schema.ts` | `ProjectionStep.find`, `AccessorSpec`, `DomainClassConfig.accessors` |
| Codegen | `scripts/generate-sdk.ts` | `emitProjection` handles `find` steps, accessor method generation |
| Domain Map | `domain-map.json` | `outputComponents` projection: `index: 0` → `find: "design"` |
| Generated | `project.ts`, `screen.ts` | `.find((c: any) => c.design)` + `getDesignMarkdown()` |

## Test plan

- [x] `npm run test` — 79 unit tests passed
- [x] `npm run test:scripts` — 58 codegen + IR tests passed
- [x] `npm run test:smoke` — all smoke checks passed
- [x] E2E: 3/3 consecutive rounds against live API (16 checks each)