### PR TITLE
fix: update generate_screen_from_text projection index from 0 to 1

### DIFF
--- a/packages/sdk/generated/domain-map.json
+++ b/packages/sdk/generated/domain-map.json
@@ -14,9 +14,7 @@
     },
     "Project": {
       "description": "A Stitch project containing screens.",
-      "constructorParams": [
-        "projectId"
-      ],
+      "constructorParams": ["projectId"],
       "fieldMapping": {
         "projectId": {
           "from": "name",
@@ -26,10 +24,7 @@
     },
     "Screen": {
       "description": "A generated UI screen. Provides access to HTML and screenshots.",
-      "constructorParams": [
-        "projectId",
-        "screenId"
-      ],
+      "constructorParams": ["projectId", "screenId"],
       "fieldMapping": {
         "projectId": {
           "from": "projectId"
@@ -103,7 +98,7 @@
         "projection": [
           {
             "prop": "outputComponents",
-            "index": 0
+            "index": 1
           },
           {
             "prop": "design"

--- a/packages/sdk/generated/src/index.ts
+++ b/packages/sdk/generated/src/index.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-21T00:17:24.039Z
+        domain-map.json     (sha256:8f41a8af5828...)
+Generated: 2026-03-29T21:29:03.291Z
  */
 export { Stitch } from "./stitch.js";
 export { Project } from "./project.js";

--- a/packages/sdk/generated/src/project.ts
+++ b/packages/sdk/generated/src/project.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-21T00:17:24.039Z
+        domain-map.json     (sha256:8f41a8af5828...)
+Generated: 2026-03-29T21:29:03.291Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";
@@ -37,7 +37,7 @@ export class Project {
     async generate(prompt: string, deviceType?: "DEVICE_TYPE_UNSPECIFIED" | "MOBILE" | "DESKTOP" | "TABLET" | "AGNOSTIC", modelId?: "MODEL_ID_UNSPECIFIED" | "GEMINI_3_PRO" | "GEMINI_3_FLASH"): Promise<Screen> {
         try {
           const raw = await this.client.callTool<any>("generate_screen_from_text", { projectId: this.projectId, prompt, deviceType, modelId });
-          const _projected = raw?.outputComponents?.[0]?.design?.screens?.[0];
+          const _projected = raw?.outputComponents?.[1]?.design?.screens?.[0];
           if (!_projected) throw new StitchError({ code: "UNKNOWN_ERROR", message: "Incomplete API response from generate_screen_from_text: expected object at projection path", recoverable: false });
           return new Screen(this.client, { ..._projected, projectId: this.projectId })
         } catch (error) {

--- a/packages/sdk/generated/src/screen.ts
+++ b/packages/sdk/generated/src/screen.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-21T00:17:24.039Z
+        domain-map.json     (sha256:8f41a8af5828...)
+Generated: 2026-03-29T21:29:03.291Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/stitch.ts
+++ b/packages/sdk/generated/src/stitch.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-21T00:17:24.039Z
+        domain-map.json     (sha256:8f41a8af5828...)
+Generated: 2026-03-29T21:29:03.291Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/tool-definitions.ts
+++ b/packages/sdk/generated/src/tool-definitions.ts
@@ -3,8 +3,8 @@
 DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:1f84b31604f9...)
-        domain-map.json     (sha256:99b823ad9306...)
-Generated: 2026-03-21T00:17:24.039Z
+        domain-map.json     (sha256:8f41a8af5828...)
+Generated: 2026-03-29T21:29:03.291Z
  */
 /** JSON Schema property descriptor for a tool parameter. */
 export interface ToolPropertySchema {

--- a/packages/sdk/generated/stitch-sdk.lock
+++ b/packages/sdk/generated/stitch-sdk.lock
@@ -1,22 +1,16 @@
 {
   "schemaVersion": 1,
-  "manifest": {
-    "capturedAt": "2026-03-06T22:22:37.041Z",
-    "sourceHash": "sha256:1f84b31604f95580325952f0c150a3e045543fad2596e9a4d8ed15c07e0cbf9b",
-    "toolCount": 8,
-    "serverUrl": "https://stitch.googleapis.com/mcp"
-  },
   "generated": {
-    "generatedAt": "2026-03-21T00:17:24.086Z",
-    "sourceHash": "sha256:8bae6b2e2940443b45a7dd8b5ee5ba73464cb213ccc22aa3bea98b1db3b66468",
+    "generatedAt": "2026-03-29T21:29:03.371Z",
+    "sourceHash": "sha256:8fac15b9bd231616f75323e77c8c929cf0730969adcf7247f1ee2a358d4ce467",
     "manifestHash": "sha256:1f84b31604f95580325952f0c150a3e045543fad2596e9a4d8ed15c07e0cbf9b",
-    "domainMapHash": "sha256:99b823ad930620c571a9443c7b956f90b092d626be9ce2319d7a7bfe3a2e3db4",
+    "domainMapHash": "sha256:8f41a8af5828f41960b19e9c2b1e1db63425827174e6bf7a292833d6b3d443e2",
     "fileCount": 5
   },
   "domainMap": {
-    "generatedAt": "2026-03-21T00:17:24.086Z",
-    "sourceHash": "sha256:99b823ad930620c571a9443c7b956f90b092d626be9ce2319d7a7bfe3a2e3db4",
-    "manifestHash": "sha256:1f84b31604f95580325952f0c150a3e045543fad2596e9a4d8ed15c07e0cbf9b",
+    "generatedAt": "2026-03-29T21:29:03.374Z",
+    "sourceHash": "sha256:8f41a8af5828f41960b19e9c2b1e1db63425827174e6bf7a292833d6b3d443e2",
+    "manifestHash": "unknown",
     "classCount": 3,
     "bindingCount": 9
   }

--- a/packages/sdk/test/unit/sdk.test.ts
+++ b/packages/sdk/test/unit/sdk.test.ts
@@ -230,6 +230,7 @@ describe("SDK Unit Tests", () => {
 
       (mockClient.callTool as Mock).mockResolvedValue({
         outputComponents: [
+          { designSystem: { name: "ds" } },
           {
             design: {
               screens: [{ id: "new-screen-1", name: "Generated", htmlCode: "<div>test</div>", projectId }],
@@ -259,7 +260,14 @@ describe("SDK Unit Tests", () => {
       const project = new Project(mockClient, projectId);
 
       (mockClient.callTool as Mock).mockResolvedValue({
-        outputComponents: [{ design: { /* screens missing */ } }],
+        outputComponents: [
+          { designSystem: { name: "ds" } },
+          {
+            design: {
+              // screens is missing
+            },
+          },
+        ],
         projectId: projectId,
       });
 


### PR DESCRIPTION
Fixes #143

## Summary

- `generate_screen_from_text` now returns `designSystem` at `outputComponents[0]`, pushing `design` to `[1]`
- `edit_screens` is unaffected — `design` remains at `[0]`
- Fix: change `generate_screen_from_text` projection index from `0` to `1` in `domain-map.json`
- Update unit test mocks to match the current API response structure

## Test plan

- [x] All 77 tests pass (`npm run test`)
- [x] Script tests pass (`npm run test:scripts`)
- [x] Smoke tests pass (`npm run test:smoke`)
- [x] Formatted with Prettier
- [x] E2E: 3/3 rounds passed (16 checks each)