### PR TITLE
feat: add buildFifeSuffix utility for high-res screenshot URLs

### DIFF
--- a/packages/sdk/src/fife.ts
+++ b/packages/sdk/src/fife.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * FIFE URL sizing utilities.
+ *
+ * Google FIFE (Fast Image Fetch Engine) serves images at a base URL.
+ * Appending sizing options (e.g. =w780, =h1200, =w780-h1688) controls
+ * the output resolution.
+ */
+
+/** Options for controlling FIFE image resolution. */
+export interface FifeImageOptions {
+  /** Requested image width in pixels. */
+  width?: number;
+  /** Requested image height in pixels. */
+  height?: number;
+}
+
+/**
+ * Build a FIFE URL sizing suffix from options.
+ *
+ * @returns A suffix string like "=w780", "=h1200", "=w780-h1688", or "" if no options.
+ */
+export function buildFifeSuffix(options?: FifeImageOptions): string {
+  if (!options) return "";
+  const parts: string[] = [];
+  if (options.width) parts.push(`w${options.width}`);
+  if (options.height) parts.push(`h${options.height}`);
+  return parts.length > 0 ? `=${parts.join("-")}` : "";
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -27,8 +27,16 @@ export { stitch } from "./singleton.js";
 // Error handling
 export { StitchError, StitchErrorCode } from "./spec/errors.js";
 
+// FIFE URL utilities
+export { buildFifeSuffix, type FifeImageOptions } from "./fife.js";
+
 // Tool catalog (generated)
-export { toolDefinitions, type ToolDefinition, type ToolInputSchema, type ToolPropertySchema } from "../generated/src/tool-definitions.js";
+export {
+  toolDefinitions,
+  type ToolDefinition,
+  type ToolInputSchema,
+  type ToolPropertySchema,
+} from "../generated/src/tool-definitions.js";
 export { toolMap, type ToolParam, type ToolInfo } from "./tool-map.js";
 
 // Types (config + data interfaces)

--- a/packages/sdk/test/unit/fife.test.ts
+++ b/packages/sdk/test/unit/fife.test.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import { buildFifeSuffix, type FifeImageOptions } from "../../src/fife.js";
+
+describe("buildFifeSuffix", () => {
+  it("returns empty string when no options", () => {
+    expect(buildFifeSuffix()).toBe("");
+  });
+
+  it("returns empty string for empty options object", () => {
+    expect(buildFifeSuffix({})).toBe("");
+  });
+
+  it("returns =w{n} for width only", () => {
+    expect(buildFifeSuffix({ width: 780 })).toBe("=w780");
+  });
+
+  it("returns =h{n} for height only", () => {
+    expect(buildFifeSuffix({ height: 1200 })).toBe("=h1200");
+  });
+
+  it("returns =w{n}-h{n} for both width and height", () => {
+    expect(buildFifeSuffix({ width: 780, height: 1688 })).toBe("=w780-h1688");
+  });
+
+  it("appends to a base URL correctly", () => {
+    const base = "https://lh3.googleusercontent.com/abc123";
+    const suffix = buildFifeSuffix({ width: 780 });
+    expect(base + suffix).toBe("https://lh3.googleusercontent.com/abc123=w780");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `buildFifeSuffix()` utility and `FifeImageOptions` type for appending FIFE sizing parameters to screenshot URLs
- Exports both from the main entry point so users can request higher-resolution images from `getImage()`

Fixes #152

## Usage

```typescript
import { buildFifeSuffix } from "@google/stitch-sdk";

const url = await screen.getImage();
const hiRes = url + buildFifeSuffix({ width: 780 });           // =w780
const both  = url + buildFifeSuffix({ width: 780, height: 1688 }); // =w780-h1688
```

## E2E verification (real FIFE service)

| Suffix | Dimensions | Size |
|--------|-----------|------|
| (none) | 187×512 | 47 KB |
| `=w780` | 780×2132 | 345 KB |
| `=w780-h1688` | 618×1688 | 316 KB |

## Test plan

- [x] `npm run test` — 87 tests pass (includes 6 new `fife.test.ts`)
- [x] `npm run test:scripts` — 57 tests pass
- [x] `npm run test:smoke` — all smoke checks pass
- [x] E2E: 3 rounds against live FIFE service, all resolve to valid images