### PR TITLE
feat: add containerized MCP proxy example

### DIFF
--- a/packages/sdk/examples/container-proxy/Containerfile
+++ b/packages/sdk/examples/container-proxy/Containerfile
@@ -1,0 +1,7 @@
+FROM docker.io/library/node:22-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production --silent
+COPY stitch-proxy.mjs .
+USER node
+ENTRYPOINT ["node", "stitch-proxy.mjs"]

--- a/packages/sdk/examples/container-proxy/README.md
+++ b/packages/sdk/examples/container-proxy/README.md
@@ -1,0 +1,68 @@
+# Containerized Stitch MCP Proxy
+
+Run the Stitch MCP proxy in a container instead of installing Node.js dependencies on the host. The API key is injected via a container secret — it never touches environment variables or command-line arguments.
+
+## Build
+
+```bash
+# Podman
+podman build -t stitch-mcp .
+
+# Docker
+docker build -t stitch-mcp .
+```
+
+## Create the API key secret
+
+```bash
+# Podman
+printf '%s' "your-stitch-api-key" | podman secret create stitch-api-key -
+
+# Docker
+printf '%s' "your-stitch-api-key" | docker secret create stitch-api-key -
+```
+
+## Run
+
+```bash
+# Podman
+podman run --rm -i --secret stitch-api-key stitch-mcp
+
+# Docker
+docker run --rm -i --secret stitch-api-key stitch-mcp
+```
+
+## Configure as an MCP server
+
+### Claude Code (`~/.claude/settings.json`)
+
+```json
+{
+  "mcpServers": {
+    "stitch": {
+      "command": "podman",
+      "args": ["run", "--rm", "-i", "--secret", "stitch-api-key", "stitch-mcp"]
+    }
+  }
+}
+```
+
+### Cursor / VS Code (`.cursor/mcp.json` or `.vscode/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "stitch": {
+      "command": "podman",
+      "args": ["run", "--rm", "-i", "--secret", "stitch-api-key", "stitch-mcp"]
+    }
+  }
+}
+```
+
+## Why containerize?
+
+- **No host dependencies** — Node.js and npm packages stay inside the container
+- **Secret isolation** — API key is read from `/run/secrets/`, never exposed as an environment variable
+- **Reproducible** — Same image runs the same way everywhere
+- **Disposable** — `--rm` cleans up after each session

--- a/packages/sdk/examples/container-proxy/package.json
+++ b/packages/sdk/examples/container-proxy/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@google/stitch-sdk": "^0.0.3"
+  }
+}

--- a/packages/sdk/examples/container-proxy/stitch-proxy.mjs
+++ b/packages/sdk/examples/container-proxy/stitch-proxy.mjs
@@ -1,0 +1,29 @@
+/**
+ * Stitch MCP Proxy — runs inside a container, reads API key from
+ * a mounted secret at /run/secrets/stitch-api-key.
+ *
+ * Build:
+ *   podman build -t stitch-mcp .
+ *
+ * Run:
+ *   podman run --rm -i --secret stitch-api-key stitch-mcp
+ */
+import { readFileSync } from 'node:fs';
+import { StitchProxy } from '@google/stitch-sdk';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const apiKey = readFileSync('/run/secrets/stitch-api-key', 'utf-8').trim();
+const proxy = new StitchProxy({ apiKey });
+const transport = new StdioServerTransport();
+
+process.on('SIGINT', async () => {
+  await proxy.close();
+  process.exit(0);
+});
+
+process.on('SIGTERM', async () => {
+  await proxy.close();
+  process.exit(0);
+});
+
+await proxy.start(transport);


### PR DESCRIPTION
## Summary

- Adds `examples/container-proxy/` — a Podman/Docker containerized deployment of the Stitch MCP proxy
- API key injected via container secrets (`/run/secrets/`), not environment variables
- Includes `Containerfile`, proxy script, and MCP client configuration examples (Claude Code, Cursor, VS Code)

## Motivation

The existing `run-proxy.ts` example requires Node.js and npm on the host. This containerized alternative:

- **No host dependencies** — Node.js and packages stay inside the container
- **Secret isolation** — API key read from `/run/secrets/`, never exposed in env vars or CLI args
- **Reproducible** — Same image, same behavior everywhere
- **Disposable** — `--rm` cleans up after each session

## Usage

```bash
podman build -t stitch-mcp .
printf '%s' "your-key" | podman secret create stitch-api-key -
podman run --rm -i --secret stitch-api-key stitch-mcp
```

## Test plan

- [x] `podman build -t stitch-mcp .` succeeds
- [x] `podman run --rm -i --secret stitch-api-key stitch-mcp` connects and discovers 12 tools
- [x] Verified as MCP server in Claude Code via `settings.json` configuration