### PR TITLE
Fixes #257: [Fleet Execution] Implement Screenshot Gallery Script Example

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -30,6 +30,11 @@ To use `stitchTools()` with the [Vercel AI SDK](https://sdk.vercel.ai/), install
 npm install @google/stitch-sdk ai
 ```
 
+## Examples
+
+Check out the [examples directory](./examples) for practical integrations, including:
+- [Screenshot Gallery](./examples/screenshot-gallery)
+
 ## Working with Projects and Screens
 
 ### List existing projects

--- a/packages/sdk/examples/screenshot-gallery/README.md
+++ b/packages/sdk/examples/screenshot-gallery/README.md
@@ -1,0 +1,26 @@
+# Screenshot Gallery
+
+This example demonstrates how to iterate over screens in a Stitch project, retrieve their screenshot URLs, and generate a simple HTML gallery page to view them.
+
+This is a deterministic **Script** example (no agent needed) that shows how to batch-process screen data.
+
+## Features demonstrated
+
+* Listing projects with `stitch.projects()`
+* Listing screens in a project with `project.screens()`
+* Fetching screenshot CDN URLs with `screen.getImage()`
+* Generating static HTML from SDK data
+
+## Prerequisites
+
+1. Set your `STITCH_API_KEY` environment variable
+2. You must have at least one project with generated screens in your account
+
+## Run the example
+
+```bash
+cd packages/sdk/examples/screenshot-gallery
+bun index.ts
+```
+
+This will create a `gallery.html` file in your current directory. Open it in any web browser to see the gallery.

--- a/packages/sdk/examples/screenshot-gallery/index.ts
+++ b/packages/sdk/examples/screenshot-gallery/index.ts
@@ -1,0 +1,123 @@
+import { stitch } from "@google/stitch-sdk";
+import fs from "fs/promises";
+import path from "path";
+import "../_require-key.js";
+
+async function run() {
+  const projects = await stitch.projects();
+  if (projects.length === 0) {
+    console.log("No projects found.");
+    return;
+  }
+
+  // Use the first project for demonstration
+  const project = projects[0];
+  console.log(`Loading screens for project: ${project.id}...`);
+
+  const screens = await project.screens();
+  if (screens.length === 0) {
+    console.log("No screens found in this project.");
+    return;
+  }
+
+  console.log(`Found ${screens.length} screens. Collecting image URLs...`);
+
+  const galleryItems = [];
+  for (const screen of screens) {
+    try {
+      const imageUrl = await screen.getImage();
+      if (imageUrl) {
+        galleryItems.push({
+          id: screen.id,
+          imageUrl
+        });
+      }
+    } catch (err) {
+      console.warn(`Failed to get image for screen ${screen.id}:`, err);
+    }
+  }
+
+  if (galleryItems.length === 0) {
+    console.log("No image URLs could be retrieved.");
+    return;
+  }
+
+  console.log(`Collected ${galleryItems.length} screenshots. Generating HTML...`);
+
+  // Generate a simple HTML gallery
+  const html = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Screenshot Gallery - ${project.id}</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      margin: 0;
+      padding: 2rem;
+      background-color: #f3f4f6;
+      color: #1f2937;
+    }
+    h1 {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    .gallery {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 2rem;
+    }
+    .gallery-item {
+      background: white;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+      transition: transform 0.2s;
+    }
+    .gallery-item:hover {
+      transform: translateY(-4px);
+    }
+    .gallery-image {
+      width: 100%;
+      height: 250px;
+      object-fit: cover;
+      object-position: top;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    .gallery-caption {
+      padding: 1rem;
+      text-align: center;
+      font-size: 0.875rem;
+      color: #6b7280;
+    }
+  </style>
+</head>
+<body>
+  <h1>Project Screenshot Gallery</h1>
+  <div class="gallery">
+    ${galleryItems.map(item => `
+    <div class="gallery-item">
+      <a href="${item.imageUrl}" target="_blank">
+        <img class="gallery-image" src="${item.imageUrl}" alt="Screenshot of screen ${item.id}" loading="lazy">
+      </a>
+      <div class="gallery-caption">Screen: ${item.id}</div>
+    </div>
+    `).join("")}
+  </div>
+</body>
+</html>
+`;
+
+  const outputPath = path.join(process.cwd(), "gallery.html");
+  await fs.writeFile(outputPath, html, "utf-8");
+
+  console.log(`\nSuccess! Generated gallery with ${galleryItems.length} screenshots.`);
+  console.log(`Open ${outputPath} in your browser to view it.`);
+}
+
+run().catch(err => {
+  console.error("Error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Fixes #257

This PR adds a deterministic script example demonstrating how to iterate over screens in a project and generate an HTML gallery of screenshot URLs.
- Creates `packages/sdk/examples/screenshot-gallery/index.ts` containing the code logic.
- Creates `packages/sdk/examples/screenshot-gallery/README.md` containing usage documentation.
- Updates `packages/sdk/README.md` to link to the new example in the top Examples section.

---
*PR created automatically by Jules for task [14083485051363723417](https://jules.google.com/task/14083485051363723417) started by @davideast*

---
⚠️ Closed by fleet-merge: batch conflict resolution dispatched (session 12887552735879190071).