### PR TITLE
Fixes #260: [Fleet Execution] Implement Next.js Page Integration Agent Skill

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,6 +2,11 @@
 
 Generate UI screens from text prompts and extract their HTML and screenshots programmatically.
 
+## Examples
+
+See the [examples/](examples/) directory for complete use cases:
+- [Next.js Integration](examples/nextjs-integration/): Agent Skill for building Next.js apps from designs.
+
 ## Quick Start
 
 Set your API key and generate a screen:

--- a/packages/sdk/examples/nextjs-integration/README.md
+++ b/packages/sdk/examples/nextjs-integration/README.md
@@ -1,0 +1,29 @@
+# Next.js Integration Agent Skill
+
+This example provides a **Skill** and a **Helper Script** that teach an agent how to scaffold a Next.js application from a Stitch-generated design.
+
+## Purpose
+
+The Stitch SDK outputs HTML containing Tailwind CSS, embedded configuration, and Google Fonts. This skill demonstrates how to bridge the gap between that raw HTML output and a functional React/Next.js App Router project.
+
+## Files
+
+- `SKILL.md`: The markdown instructions to provide to an autonomous agent.
+- `scripts/scaffold-nextjs.ts`: A script the agent can run to automate the extraction of assets from a specific Stitch screen.
+
+## Running the Script
+
+Ensure you have your API key set:
+```bash
+export STITCH_API_KEY="your-api-key"
+```
+
+To run the script:
+```bash
+bun run scripts/scaffold-nextjs.ts <projectId> <screenId>
+```
+
+This will produce three files in your current directory:
+- `tailwind.config.extracted.js`
+- `extracted-fonts.txt`
+- `extracted-page.html`

--- a/packages/sdk/examples/nextjs-integration/SKILL.md
+++ b/packages/sdk/examples/nextjs-integration/SKILL.md
@@ -1,0 +1,47 @@
+# Skill: Next.js Integration from Stitch Designs
+
+This skill teaches an agent how to adapt a Stitch SDK generated UI screen into a Next.js App Router project.
+
+## Workflow
+
+When tasked with generating a Next.js application from a prompt:
+
+1. **Generate the Design**: Use the Stitch SDK to generate the screen (e.g. via `project.generate(prompt)` or `generate_screen_from_text` tool).
+2. **Extract Assets**:
+   - Fetch the HTML string using `screen.getHtml()`.
+   - The HTML will contain:
+     - A `<script id="tailwind-config">` block with theme variables (colors, fonts).
+     - Google Fonts `<link>` tags in the `<head>`.
+     - Raw HTML with Tailwind CSS classes in the `<body>`.
+3. **Scaffold Next.js Structure**:
+   - Create a standard Next.js App Router skeleton (`app/layout.tsx`, `app/page.tsx`).
+4. **Map Tailwind Configuration**:
+   - Extract the JSON-like object from the `<script id="tailwind-config">` block.
+   - Write it to `tailwind.config.ts`.
+5. **Map Fonts**:
+   - Extract the font families from the Google Fonts tags.
+   - Use `next/font/google` in `app/layout.tsx` to inject them, or add standard `<link>` tags if preferred in the raw layout.
+6. **Adapt HTML to JSX**:
+   - Convert the `<body>` HTML into valid JSX in `app/page.tsx`.
+   - Replace `class=` with `className=`.
+   - Replace self-closing tags to conform to JSX (e.g., `<img>` -> `<img />`, `<input>` -> `<input />`).
+   - Replace inline styles to React-compatible objects (e.g., `style="background-image: url(...)"` -> `style={{ backgroundImage: "url(...)" }}`).
+   - **Next.js specifics**:
+     - Convert standard `<img>` tags to `<Image>` components from `next/image`, updating `src`, `width`, and `height` props.
+     - Convert standard `<a>` tags for internal routing to `<Link>` components from `next/link`.
+
+## Using the Helper Script
+
+This directory contains a helper script `scripts/scaffold-nextjs.ts` which automates steps 1-4.
+
+You can run it from the root of a Next.js project to automatically pull down the design and scaffold the necessary configurations:
+
+```bash
+cd my-next-app
+bun run /path/to/packages/sdk/examples/nextjs-integration/scripts/scaffold-nextjs.ts "<your project id>" "<your screen id>"
+```
+
+The script will write:
+- `tailwind.config.extracted.js` (You need to manually merge this with `tailwind.config.ts`)
+- `extracted-fonts.txt` (List of fonts to add to `app/layout.tsx`)
+- `extracted-page.html` (The raw HTML to convert to JSX)

--- a/packages/sdk/examples/nextjs-integration/scripts/scaffold-nextjs.ts
+++ b/packages/sdk/examples/nextjs-integration/scripts/scaffold-nextjs.ts
@@ -1,0 +1,71 @@
+import { stitch } from "@google/stitch-sdk";
+import * as fs from "fs";
+import * as path from "path";
+import "../../../_require-key.js";
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error("Usage: bun run scaffold-nextjs.ts <projectId> <screenId>");
+    process.exit(1);
+  }
+
+  const projectId = args[0];
+  const screenId = args[1];
+
+  console.log(`Fetching design from project ${projectId}, screen ${screenId}...`);
+
+  const project = stitch.project(projectId);
+  // Using screens() because getScreen() is not available
+  const screens = await project.screens();
+  const screen = screens.find((s: any) => s.id === screenId || s.screenId === screenId);
+
+  if (!screen) {
+    console.error(`Screen ${screenId} not found in project ${projectId}`);
+    process.exit(1);
+  }
+
+  const htmlUrl = await screen.getHtml();
+  let html = htmlUrl;
+  if (htmlUrl.startsWith("http")) {
+    const resp = await fetch(htmlUrl);
+    html = await resp.text();
+  }
+
+  // 1. Extract Tailwind Config
+  const configMatch = html.match(/<script id="tailwind-config">([\s\S]*?)<\/script>/);
+  if (configMatch && configMatch[1]) {
+    const configContent = configMatch[1].trim();
+    const cleanConfig = configContent.replace(/^tailwind\.config\s*=\s*/, "").replace(/;$/, "");
+    const outputConfig = `/** @type {import('tailwindcss').Config} */\nmodule.exports = ${cleanConfig};\n`;
+    fs.writeFileSync("tailwind.config.extracted.js", outputConfig);
+    console.log("✅ Extracted Tailwind config to tailwind.config.extracted.js");
+  } else {
+    console.warn("⚠️ No tailwind-config block found in HTML.");
+  }
+
+  // 2. Extract Google Fonts
+  const fonts = html.match(/<link[^>]*fonts\.googleapis\.com[^>]*>/g) || [];
+  if (fonts.length > 0) {
+    fs.writeFileSync("extracted-fonts.txt", fonts.join("\n") + "\n");
+    console.log("✅ Extracted Google Fonts to extracted-fonts.txt");
+  } else {
+    console.warn("⚠️ No Google Fonts found in HTML.");
+  }
+
+  // 3. Extract Body HTML
+  const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  if (bodyMatch && bodyMatch[1]) {
+    fs.writeFileSync("extracted-page.html", bodyMatch[1].trim() + "\n");
+    console.log("✅ Extracted body HTML to extracted-page.html");
+  } else {
+    console.warn("⚠️ No <body> tag found in HTML.");
+  }
+
+  console.log("\nNext Steps:");
+  console.log("1. Merge tailwind.config.extracted.js into your Next.js tailwind.config.ts");
+  console.log("2. Use next/font/google to load the fonts listed in extracted-fonts.txt in your layout.tsx");
+  console.log("3. Convert the HTML in extracted-page.html to JSX (className, self-closing tags) in your page.tsx");
+}
+
+main().catch(console.error);


### PR DESCRIPTION
This PR adds the Tier 2 Agent Skill for generating Next.js applications from Stitch UI designs, fulfilling Issue #260.

Changes:
- Added `packages/sdk/examples/nextjs-integration/SKILL.md` detailing instructions for an autonomous agent to map Tailwind configuration, adapt standard HTML tags to `next/image` and `next/link`, and wrap assets into a Next.js App Router structure.
- Created `packages/sdk/examples/nextjs-integration/scripts/scaffold-nextjs.ts` to automate asset extraction.
- Created `packages/sdk/examples/nextjs-integration/README.md`.
- Updated `packages/sdk/README.md` to link to the new example in a dedicated Examples section.

Fixes #260

---
*PR created automatically by Jules for task [13863354906900995958](https://jules.google.com/task/13863354906900995958) started by @davideast*

---
⚠️ Closed by fleet-merge: batch conflict resolution dispatched (session 12887552735879190071).