### PR TITLE
Fixes #264: Add stitch-cli example

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -298,3 +298,5 @@ Program](https://bughunters.google.com/open-source-security).
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE) for details.
+## Examples
+- [Stitch CLI](examples/stitch-cli/README.md) - An agent-first CLI wrapper demonstrating JSON input/output and schema introspection.

--- a/packages/sdk/examples/stitch-cli/README.md
+++ b/packages/sdk/examples/stitch-cli/README.md
@@ -1,0 +1,19 @@
+# Stitch CLI Example
+
+This example demonstrates an Agent CLI, wrapping the `@google/stitch-sdk` into an agent-friendly command-line interface.
+
+## Agent Ergonomics
+- Every command accepts a `--json` flag to output machine-readable JSON.
+- Inputs are passed as serialized JSON strings.
+- Input validation and schema introspection via `schema` commands.
+
+## Prerequisites
+Set your API key before running the CLI:
+```bash
+export STITCH_API_KEY="your-api-key"
+```
+
+## Run
+```bash
+bun src/cli.ts --help
+```

--- a/packages/sdk/examples/stitch-cli/SKILL.md
+++ b/packages/sdk/examples/stitch-cli/SKILL.md
@@ -1,0 +1,24 @@
+# Stitch CLI Skill
+
+## Overview
+The Stitch CLI provides a machine-readable, agent-first interface for generating and exporting UI screens. It allows agents to use the Stitch SDK safely and efficiently through command-line operations with `--json` outputs.
+
+## Features
+- Introspection: Fetch JSON schemas for expected input using `schema generate`
+- Clean Output: Pass `--json` to all commands for easily parsable responses
+- Sandboxed Errors: Avoid runtime stack traces; errors are formatted explicitly as JSON
+
+## Usage
+```bash
+# Find out schema details
+bun packages/sdk/examples/stitch-cli/src/cli.ts schema generate
+
+# Generate a screen
+bun packages/sdk/examples/stitch-cli/src/cli.ts generate --json '{"projectId": "...", "prompt": "..."}'
+
+# Export URLs
+bun packages/sdk/examples/stitch-cli/src/cli.ts export --json '{"projectId": "...", "screenId": "..."}'
+
+# Extract Theme
+bun packages/sdk/examples/stitch-cli/src/cli.ts extract-theme --json '{"projectId": "...", "screenId": "..."}'
+```

--- a/packages/sdk/examples/stitch-cli/src/cli.ts
+++ b/packages/sdk/examples/stitch-cli/src/cli.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+import { stitch } from "@google/stitch-sdk";
+
+if (!process.env.STITCH_API_KEY) {
+  console.error("Error: STITCH_API_KEY environment variable is required.");
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+  console.log(`
+Stitch CLI Tool
+
+Usage:
+  stitch-cli <command> [options]
+
+Commands:
+  generate      Generate a new screen
+  export        Export an existing screen's HTML or image
+  extract-theme Extract the Tailwind config from a screen
+  schema        Print JSON schemas for inputs
+
+Global Options:
+  --json        Output result as JSON for agents
+`);
+  process.exit(0);
+}
+
+const command = args[0];
+const isJson = args.includes("--json");
+
+function getJsonPayload(argsList: string[]): string {
+  // Find the first argument that looks like JSON after trimming whitespace
+  const match = argsList.find(a => a.trim().startsWith("{"));
+  if (!match) {
+    throw new Error(`Missing JSON payload for ${command}`);
+  }
+  return match.trim();
+}
+
+async function main() {
+  try {
+    if (command === "generate") {
+      const inputArg = getJsonPayload(args);
+      const input = JSON.parse(inputArg);
+
+      if (!input.projectId || !input.prompt) throw new Error("Missing projectId or prompt");
+      const project = stitch.project(input.projectId);
+      const screen = await project.generate(input.prompt);
+
+      if (isJson) {
+        console.log(JSON.stringify({
+          screenId: screen.id,
+          projectId: screen.projectId
+        }, null, 2));
+      } else {
+        console.log(`Generated screen ${screen.id} in project ${screen.projectId}`);
+      }
+    } else if (command === "export") {
+      const inputArg = getJsonPayload(args);
+      const input = JSON.parse(inputArg);
+
+      if (!input.projectId || !input.screenId) throw new Error("Missing projectId or screenId");
+      const project = stitch.project(input.projectId);
+      const screens = await project.screens();
+      const screen = screens.find((s: any) => s.id === input.screenId);
+      if (!screen) throw new Error("Screen not found");
+
+      const htmlUrl = await screen.getHtml();
+      const imageUrl = await screen.getImage();
+
+      if (isJson) {
+        console.log(JSON.stringify({
+          htmlUrl,
+          imageUrl
+        }, null, 2));
+      } else {
+        console.log(`HTML: ${htmlUrl}\nImage: ${imageUrl}`);
+      }
+    } else if (command === "extract-theme") {
+       const inputArg = getJsonPayload(args);
+       const input = JSON.parse(inputArg);
+
+       if (!input.projectId || !input.screenId) throw new Error("Missing projectId or screenId");
+       const project = stitch.project(input.projectId);
+       const screens = await project.screens();
+       const screen = screens.find((s: any) => s.id === input.screenId);
+       if (!screen) throw new Error("Screen not found");
+
+       const htmlData = await screen.getHtml();
+       let html = "";
+       if (htmlData && htmlData.startsWith("http")) {
+         const resp = await fetch(htmlData);
+         html = await resp.text();
+       } else {
+         html = htmlData;
+       }
+
+       const configMatch = html.match(/<script id="tailwind-config">([\s\S]*?)<\/script>/);
+       const theme = configMatch ? configMatch[1] : null;
+
+       if (isJson) {
+         console.log(JSON.stringify({ theme }, null, 2));
+       } else {
+         console.log(theme ?? "No theme found.");
+       }
+    } else if (command === "schema") {
+       const subCommand = args[1];
+       if (subCommand === "generate") {
+         console.log(JSON.stringify({
+            type: "object",
+            properties: {
+              projectId: { type: "string" },
+              prompt: { type: "string" }
+            },
+            required: ["projectId", "prompt"]
+         }, null, 2));
+       } else {
+         console.log(JSON.stringify({
+            commands: ["generate", "export", "extract-theme"]
+         }, null, 2));
+       }
+    } else {
+      throw new Error(`Unknown command: ${command}`);
+    }
+  } catch (error: any) {
+    if (isJson) {
+      console.error(JSON.stringify({ error: error.message }));
+    } else {
+      console.error(`Error: ${error.message}`);
+    }
+    process.exit(1);
+  }
+}
+
+await main();


### PR DESCRIPTION
Fixes #264

This PR adds an Agent CLI wrapper around the `@google/stitch-sdk` demonstrating JSON input/output formatting and schema introspection, geared toward integration with automated agent workflows. 

Included:
- `stitch-cli/src/cli.ts` implementation.
- Agent-oriented `SKILL.md` instruction file.
- `README.md` documentation.
- Link added to the main SDK `README.md`.

---
*PR created automatically by Jules for task [10572034081433410731](https://jules.google.com/task/10572034081433410731) started by @davideast*

---
⚠️ Closed by fleet-merge: batch conflict resolution dispatched (session 12887552735879190071).