### PR TITLE
feat(proxy): support accessToken auth alongside apiKey

### DIFF
--- a/packages/sdk/src/proxy/client.ts
+++ b/packages/sdk/src/proxy/client.ts
@@ -24,6 +24,20 @@ export interface ProxyContext {
 }
 
 /**
+ * Build the appropriate auth headers based on config.
+ */
+function buildAuthHeaders(config: StitchProxyConfig): Record<string, string> {
+    if (config.accessToken) {
+        const headers: Record<string, string> = { Authorization: `Bearer ${config.accessToken}` };
+        if (config.quotaProjectId) {
+            headers['X-Goog-User-Project'] = config.quotaProjectId;
+        }
+        return headers;
+    }
+    return { 'X-Goog-Api-Key': config.apiKey! };
+}
+
+/**
  * Forward a JSON-RPC request to Stitch.
  */
 export async function forwardToStitch(
@@ -45,7 +59,7 @@ export async function forwardToStitch(
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        'X-Goog-Api-Key': config.apiKey!,
+        ...buildAuthHeaders(config),
       },
       body: JSON.stringify(request),
     });
@@ -92,7 +106,7 @@ export async function initializeStitchConnection(
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
-      'X-Goog-Api-Key': ctx.config.apiKey!,
+      ...buildAuthHeaders(ctx.config),
     },
     body: JSON.stringify({
       jsonrpc: '2.0',

--- a/packages/sdk/src/proxy/core.ts
+++ b/packages/sdk/src/proxy/core.ts
@@ -32,6 +32,8 @@ export class StitchProxy implements StitchProxySpec {
   constructor(inputConfig?: Partial<StitchProxyConfig>) {
     const rawConfig = {
       apiKey: inputConfig?.apiKey || process.env.STITCH_API_KEY,
+      accessToken: inputConfig?.accessToken || process.env.STITCH_ACCESS_TOKEN,
+      quotaProjectId: inputConfig?.quotaProjectId || process.env.STITCH_PROJECT_ID || process.env.GOOGLE_CLOUD_PROJECT,
       url: inputConfig?.url || process.env.STITCH_MCP_URL,
       name: inputConfig?.name,
       version: inputConfig?.version,
@@ -40,8 +42,8 @@ export class StitchProxy implements StitchProxySpec {
     // Validate config
     this.config = StitchProxyConfigSchema.parse(rawConfig);
 
-    if (!this.config.apiKey) {
-      throw new Error('StitchProxy requires an API key (STITCH_API_KEY)');
+    if (!this.config.apiKey && !this.config.accessToken) {
+      throw new Error('StitchProxy requires an API key (STITCH_API_KEY) or access token (STITCH_ACCESS_TOKEN)');
     }
 
     this.server = new McpServer(

--- a/packages/sdk/src/spec/proxy.ts
+++ b/packages/sdk/src/spec/proxy.ts
@@ -23,6 +23,12 @@ export const StitchProxyConfigSchema = z.object({
   /** API key for Stitch authentication. Falls back to STITCH_API_KEY. */
   apiKey: z.string().optional(),
 
+  /** Access token for Stitch authentication (Bearer). Falls back to STITCH_ACCESS_TOKEN. */
+  accessToken: z.string().optional(),
+
+  /** Quota project ID for billing. Required with accessToken auth. Falls back to STITCH_PROJECT_ID or GOOGLE_CLOUD_PROJECT. */
+  quotaProjectId: z.string().optional(),
+
   /** Target Stitch MCP URL. Default: https://stitch.googleapis.com/mcp */
   url: z.string().default(DEFAULT_STITCH_API_URL),
 

--- a/packages/sdk/test/proxy.test.ts
+++ b/packages/sdk/test/proxy.test.ts
@@ -43,9 +43,25 @@ describe('StitchProxy', () => {
     expect(proxy).toBeDefined();
   });
 
-  it('should throw if no API key is provided', () => {
+  it('should throw if neither API key nor access token is provided', () => {
     delete process.env.STITCH_API_KEY;
-    expect(() => new StitchProxy({})).toThrow("StitchProxy requires an API key");
+    delete process.env.STITCH_ACCESS_TOKEN;
+    expect(() => new StitchProxy({})).toThrow("StitchProxy requires an API key (STITCH_API_KEY) or access token (STITCH_ACCESS_TOKEN)");
+  });
+
+  it('should initialize with accessToken instead of apiKey', () => {
+    delete process.env.STITCH_API_KEY;
+    delete process.env.STITCH_ACCESS_TOKEN;
+    const proxy = new StitchProxy({ accessToken: 'test-token' });
+    expect(proxy).toBeDefined();
+  });
+
+  it('should initialize with STITCH_ACCESS_TOKEN env var', () => {
+    delete process.env.STITCH_API_KEY;
+    process.env.STITCH_ACCESS_TOKEN = 'env-token';
+    const proxy = new StitchProxy({});
+    expect(proxy).toBeDefined();
+    delete process.env.STITCH_ACCESS_TOKEN;
   });
 
   it('should connect to stitch and fetch tools on start', async () => {
@@ -97,6 +113,37 @@ describe('Proxy Client Error Handling', () => {
   afterEach(() => {
     global.fetch = globalFetch;
     vi.clearAllMocks();
+  });
+
+  it('forwardToStitch should send Authorization: Bearer header when accessToken is configured', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: 'ok' })
+    } as Response);
+
+    await forwardToStitch({ url: 'http://test', accessToken: 'my-token', quotaProjectId: 'my-project' } as any, 'testMethod');
+
+    const fetchCall = mockFetch.mock.calls[0];
+    expect(fetchCall[1].headers).toEqual(expect.objectContaining({
+      Authorization: 'Bearer my-token',
+      'X-Goog-User-Project': 'my-project',
+    }));
+    expect(fetchCall[1].headers).not.toHaveProperty('X-Goog-Api-Key');
+  });
+
+  it('forwardToStitch should send X-Goog-Api-Key header when only apiKey is configured', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: 'ok' })
+    } as Response);
+
+    await forwardToStitch({ url: 'http://test', apiKey: 'my-api-key' } as any, 'testMethod');
+
+    const fetchCall = mockFetch.mock.calls[0];
+    expect(fetchCall[1].headers).toEqual(expect.objectContaining({
+      'X-Goog-Api-Key': 'my-api-key',
+    }));
+    expect(fetchCall[1].headers).not.toHaveProperty('Authorization');
   });
 
   it('forwardToStitch should throw Stitch API error on non-ok response', async () => {


### PR DESCRIPTION
## Summary

- Add `accessToken` as an alternative authentication method in the proxy module's Zod schema, constructor, and HTTP client
- When `accessToken` is provided (via config or `STITCH_ACCESS_TOKEN` env var), the proxy sends `Authorization: Bearer` headers instead of `X-Goog-Api-Key`
- Add `quotaProjectId` to send `X-Goog-User-Project` header with Bearer auth (required by Google APIs for billing/quota)
- The proxy now accepts either `apiKey` or `accessToken`, throwing only if neither is provided

## Motivation

The proxy module currently only supports API key authentication (`X-Goog-Api-Key`), but the Stitch service layer already supports access tokens. This PR adds `accessToken` support to the proxy module to enable ADC/OAuth2 workflows, which is especially important for Windows users where system-level `gcloud` integration is needed and API keys may not be the preferred auth method.

## Changes

- **`spec/proxy.ts`** — Added `accessToken` and `quotaProjectId` to `StitchProxyConfigSchema`
- **`proxy/core.ts`** — Constructor reads `accessToken` and `quotaProjectId` from config/env vars; validation guard accepts either credential
- **`proxy/client.ts`** — New `buildAuthHeaders()` helper selects `Authorization: Bearer` + `X-Goog-User-Project` or `X-Goog-Api-Key` headers
- **`test/proxy.test.ts`** — 4 new tests covering accessToken init, env var init, error on missing credentials, and header verification

## Test plan

- [x] Verify proxy starts with `STITCH_API_KEY` set (existing behavior unchanged)
- [x] Verify proxy starts with `STITCH_ACCESS_TOKEN` set (new behavior)
- [x] Verify proxy throws if neither key nor token is provided
- [x] Verify `Authorization: Bearer` + `X-Goog-User-Project` headers sent with accessToken
- [x] Verify `X-Goog-Api-Key` header is sent when only apiKey is configured
- [x] Verified end-to-end: `create_project` tool call succeeds with Bearer + quota project

All 97 tests passing (14 test files).