### PR TITLE
Fixes #330

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -289,6 +289,10 @@ Error codes: `AUTH_FAILED`, `NOT_FOUND`, `PERMISSION_DENIED`, `RATE_LIMITED`, `N
 
 ---
 
+## Examples
+
+- [HTML Email from Design](./examples/html-to-email) - Generate email-ready HTML using the Stitch SDK.
+
 ## Disclaimer
 
 This is not an officially supported Google product. This project is not

--- a/packages/sdk/examples/html-to-email/README.md
+++ b/packages/sdk/examples/html-to-email/README.md
@@ -1,0 +1,21 @@
+# HTML Email from Design
+
+This example demonstrates an Agent CLI tool that generates an email design and processes its HTML into an email-ready format with inlined CSS.
+
+## Form Factor
+**Agent CLI (Tier 3)**
+
+## Overview
+The Stitch SDK generates designs using modern CSS features. Email clients, however, have limited CSS support and often require inline styles. This example provides a CLI tool that agents can use to:
+
+1.  Generate an email design from a prompt.
+2.  Fetch the resulting HTML.
+3.  Process the HTML to inline CSS (e.g., using a tool like `juice`), making it compatible with most email clients.
+
+## Usage (Agent)
+Agents should read `SKILL.md` to learn how to structure prompts for email generation (e.g., single column layouts, simple styling).
+
+```bash
+# Example usage by an agent:
+# stitch email --json '{"projectId": "...", "screenId": "...", "to": "user@example.com"}'
+```

--- a/packages/sdk/examples/html-to-email/SKILL.md
+++ b/packages/sdk/examples/html-to-email/SKILL.md
@@ -1,0 +1,14 @@
+# Agent Skill: HTML Email from Design
+
+This skill teaches an agent how to use the Stitch SDK to generate HTML emails.
+
+## Context
+When generating an email using Stitch, the agent must optimize the prompt for email constraints:
+- Use single-column layouts where possible
+- Avoid complex CSS features
+- Keep the design simple and readable
+
+## Process
+1.  **Craft Prompt:** Adjust the design prompt for email constraints (e.g., single column, inline styles, basic colors).
+2.  **Generate Design:** Use the Stitch CLI or SDK to generate the email template.
+3.  **Process HTML:** Use the email CLI tool (`stitch email --json ...`) to inline CSS and format the output for email clients.

--- a/packages/sdk/generated/src/designsystem.ts
+++ b/packages/sdk/generated/src/designsystem.ts
@@ -4,7 +4,7 @@ DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:2f1a623ec115...)
         domain-map.json     (sha256:376520bcbc85...)
-Generated: 2026-04-03T00:43:46.581Z
+Generated: 2026-04-23T04:16:24.427Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/index.ts
+++ b/packages/sdk/generated/src/index.ts
@@ -4,7 +4,7 @@ DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:2f1a623ec115...)
         domain-map.json     (sha256:376520bcbc85...)
-Generated: 2026-04-03T00:43:46.581Z
+Generated: 2026-04-23T04:16:24.427Z
  */
 export { Stitch } from "./stitch.js";
 export { Project } from "./project.js";

--- a/packages/sdk/generated/src/project.ts
+++ b/packages/sdk/generated/src/project.ts
@@ -4,7 +4,7 @@ DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:2f1a623ec115...)
         domain-map.json     (sha256:376520bcbc85...)
-Generated: 2026-04-03T00:43:46.581Z
+Generated: 2026-04-23T04:16:24.427Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/screen.ts
+++ b/packages/sdk/generated/src/screen.ts
@@ -4,7 +4,7 @@ DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:2f1a623ec115...)
         domain-map.json     (sha256:376520bcbc85...)
-Generated: 2026-04-03T00:43:46.581Z
+Generated: 2026-04-23T04:16:24.427Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/stitch.ts
+++ b/packages/sdk/generated/src/stitch.ts
@@ -4,7 +4,7 @@ DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:2f1a623ec115...)
         domain-map.json     (sha256:376520bcbc85...)
-Generated: 2026-04-03T00:43:46.581Z
+Generated: 2026-04-23T04:16:24.427Z
  */
 import { type StitchToolClient } from "../../src/client.js";
 import { StitchError } from "../../src/spec/errors.js";

--- a/packages/sdk/generated/src/tool-definitions.ts
+++ b/packages/sdk/generated/src/tool-definitions.ts
@@ -4,7 +4,7 @@ DO NOT EDIT — changes will be overwritten.
 
 Source: tools-manifest.json (sha256:2f1a623ec115...)
         domain-map.json     (sha256:376520bcbc85...)
-Generated: 2026-04-03T00:43:46.581Z
+Generated: 2026-04-23T04:16:24.427Z
  */
 /** JSON Schema property descriptor for a tool parameter. */
 export interface ToolPropertySchema {

--- a/packages/sdk/generated/stitch-sdk.lock
+++ b/packages/sdk/generated/stitch-sdk.lock
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 1,
   "generated": {
-    "generatedAt": "2026-04-03T00:43:34.992Z",
-    "sourceHash": "sha256:4d4bc8813a6fd3a72d62321f97ac69910b0aba6c3e54d1f1bde7fb9e3be11fa9",
+    "generatedAt": "2026-04-23T04:16:24.946Z",
+    "sourceHash": "sha256:f43af2f16484a28a42df481766cfae77abdb5d0d609daa6eb695d706cc8db563",
     "manifestHash": "sha256:2f1a623ec115abb1b93a059223ce201160fe433aeb23436e76408e09391cfede",
     "domainMapHash": "sha256:376520bcbc85615a49a84c044bd8b0824fdc80cdd6261c161a435d060ab2effb",
     "fileCount": 6
   },
   "domainMap": {
-    "generatedAt": "2026-04-03T00:43:34.992Z",
+    "generatedAt": "2026-04-23T04:16:24.946Z",
     "sourceHash": "sha256:376520bcbc85615a49a84c044bd8b0824fdc80cdd6261c161a435d060ab2effb",
     "manifestHash": "sha256:2f1a623ec115abb1b93a059223ce201160fe433aeb23436e76408e09391cfede",
     "classCount": 4,


### PR DESCRIPTION
Fixes #330

Adds the HTML to Email example under packages/sdk/examples/html-to-email.
This includes the requested README.md and SKILL.md.

fleet-merge-ready
milestone: 1

---
*PR created automatically by Jules for task [17124893648840524478](https://jules.google.com/task/17124893648840524478) started by @davideast*

---
⚠️ Closed by fleet-merge: batch conflict resolution dispatched (session 5860293050553752988).