### PR TITLE
fix: scan outputComponents instead of hardcoding array index

### DIFF
--- a/packages/sdk/generated/domain-map.json
+++ b/packages/sdk/generated/domain-map.json
@@ -115,7 +115,7 @@
         "projection": [
           {
             "prop": "outputComponents",
-            "index": 1
+            "find": "design.screens"
           },
           {
             "prop": "design"
@@ -156,7 +156,7 @@
         "projection": [
           {
             "prop": "outputComponents",
-            "index": 0
+            "find": "design.screens"
           },
           {
             "prop": "design"

--- a/packages/sdk/generated/src/project.ts
+++ b/packages/sdk/generated/src/project.ts
@@ -38,7 +38,7 @@ export class Project {
     async generate(prompt: string, deviceType?: "DEVICE_TYPE_UNSPECIFIED" | "MOBILE" | "DESKTOP" | "TABLET" | "AGNOSTIC", modelId?: "MODEL_ID_UNSPECIFIED" | "GEMINI_3_PRO" | "GEMINI_3_FLASH" | "GEMINI_3_1_PRO"): Promise<Screen> {
         try {
           const raw = await this.client.callTool<any>("generate_screen_from_text", { projectId: this.projectId, prompt, deviceType, modelId });
-          const _projected = raw?.outputComponents?.[1]?.design?.screens?.[0];
+          const _projected = (raw?.outputComponents ?? []).map((c: any) => c?.design?.screens?.[0]).find((s: any) => s != null);
           if (!_projected) throw new StitchError({ code: "UNKNOWN_ERROR", message: "Incomplete API response from generate_screen_from_text: expected object at projection path", recoverable: false });
           return new Screen(this.client, { ..._projected, projectId: this.projectId })
         } catch (error) {

--- a/packages/sdk/generated/src/screen.ts
+++ b/packages/sdk/generated/src/screen.ts
@@ -38,7 +38,7 @@ export class Screen {
     async edit(prompt: string, deviceType?: "DEVICE_TYPE_UNSPECIFIED" | "MOBILE" | "DESKTOP" | "TABLET" | "AGNOSTIC", modelId?: "MODEL_ID_UNSPECIFIED" | "GEMINI_3_PRO" | "GEMINI_3_FLASH" | "GEMINI_3_1_PRO"): Promise<Screen> {
         try {
           const raw = await this.client.callTool<any>("edit_screens", { projectId: this.projectId, selectedScreenIds: [this.screenId], prompt, deviceType, modelId });
-          const _projected = raw?.outputComponents?.[0]?.design?.screens?.[0];
+          const _projected = (raw?.outputComponents ?? []).map((c: any) => c?.design?.screens?.[0]).find((s: any) => s != null);
           if (!_projected) throw new StitchError({ code: "UNKNOWN_ERROR", message: "Incomplete API response from edit_screens: expected object at projection path", recoverable: false });
           return new Screen(this.client, { ..._projected, projectId: this.projectId })
         } catch (error) {

--- a/packages/sdk/test/unit/sdk.test.ts
+++ b/packages/sdk/test/unit/sdk.test.ts
@@ -136,6 +136,23 @@ describe("SDK Unit Tests", () => {
       expect(edited.id).toBe("edited-screen");
     });
 
+    it("edit should find screen when a prefix block is present", async () => {
+      const screen = new Screen(mockClient, screenData);
+
+      (mockClient.callTool as Mock).mockResolvedValue({
+        outputComponents: [
+          { designSystem: { name: "ds-update" } },
+          { design: { screens: [{ id: "edited-2", htmlCode: "<div>Dark</div>", projectId }] } },
+        ],
+        projectId,
+        sessionId: "session-2",
+      });
+
+      const edited = await screen.edit("Make it dark");
+      expect(edited).toBeInstanceOf(Screen);
+      expect(edited.id).toBe("edited-2");
+    });
+
     it("edit should throw StitchError (not TypeError) when response has no screens", async () => {
       const screen = new Screen(mockClient, screenData);
 
@@ -253,6 +270,29 @@ describe("SDK Unit Tests", () => {
       expect(result).toBeInstanceOf(Screen);
       expect(result.id).toBe("new-screen-1");
       expect(result.projectId).toBe(projectId);
+    });
+
+    it("generate should find screen when designSystem block is absent (issue #315)", async () => {
+      const project = new Project(mockClient, projectId);
+
+      (mockClient.callTool as Mock).mockResolvedValue({
+        outputComponents: [
+          {
+            design: {
+              screens: [{ id: "screen-2", name: "Second", htmlCode: "<div>2</div>", projectId }],
+            },
+          },
+          { text: "summary" },
+          { suggestion: "try this" },
+        ],
+        projectId: projectId,
+        sessionId: "session-2",
+      });
+
+      const result = await project.generate("Second page");
+
+      expect(result).toBeInstanceOf(Screen);
+      expect(result.id).toBe("screen-2");
     });
 
 


### PR DESCRIPTION
Project.generate() hardcoded outputComponents[1] to find the screen. The Stitch API omits the designSystem prefix block on 2nd+ calls, shifting the screen to index 0 and causing a StitchError.

Screen.edit() had the same fragility with a hardcoded index 0.

Both methods now scan outputComponents for the first entry with design.screens[0], matching the robust pattern already used by Screen.variants() and DesignSystem.apply().

Also updates domain-map.json to use 'find: design.screens' so the next codegen run produces scanning code instead of reverting.

Fixes #315.