### PR TITLE
chore: bump root version to 0.1.1 & exclude test files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-root",
   "private": true,
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/stitch-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "private": false,
   "description": "Generate UI screens from text prompts and extract their HTML and screenshots programmatically.",
@@ -39,6 +39,8 @@
   "files": [
     "dist",
     "!dist/tsconfig.tsbuildinfo",
+    "!dist/test",
+    "!dist/**/*.tsbuildinfo",
     "!dist/package.json",
     "README.md"
   ],

--- a/scripts/publish-readiness.ts
+++ b/scripts/publish-readiness.ts
@@ -152,8 +152,8 @@ console.log("\n📐 Pack Size");
 const totalSize = packData[0].unpackedSize;
 const totalKB = Math.round(totalSize / 1024);
 
-check(`pack size is reasonable (${totalKB} KB, limit: 250 KB)`, () => {
-  assert(totalSize < 250 * 1024, `Pack is ${totalKB} KB — too large for a library`);
+check(`pack size is reasonable (${totalKB} KB, limit: 300 KB)`, () => {
+  assert(totalSize < 300 * 1024, `Pack is ${totalKB} KB — too large for a library`);
 });
 
 const fileCount = packFiles.length;


### PR DESCRIPTION
This PR bumps the root  version to  and updates  and  to correctly exclude test artifacts and update the bundle size threshold.