### PR TITLE
chore: Bump SDK version to 0.3.4 & set publish tag to latest

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/stitch-sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "private": false,
   "description": "Generate UI screens from text prompts and extract their HTML and screenshots programmatically.",
@@ -47,7 +47,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com",
     "access": "public",
-    "tag": "next"
+    "tag": "latest"
   },
   "scripts": {
     "build": "bun scripts/inject-version.ts && tsc",


### PR DESCRIPTION
This PR bumps the SDK version to `0.3.4` and updates the `publishConfig.tag` in `package.json` to `latest`, making the resilient schema repair release available as the default library release on the registry.